### PR TITLE
fix: use unique enum value for Direction.UpLeft

### DIFF
--- a/packages/types/src/Player.ts
+++ b/packages/types/src/Player.ts
@@ -30,7 +30,7 @@ export enum Direction {
     UpRight = 1.5,
     DownRight = 2.5,
     DownLeft = 3.5,
-    UpLeft =  2.5
+    UpLeft =  4.5
 }
 
 export type ClientMode =  MoveClientMode | { 


### PR DESCRIPTION
Should this be `0.5` or `4.5 `instead? Considering how the other mixed directions values are. Now UpLeft is conflicting with DownRight.