### PR TITLE
Failed to resolve entry for package "fs". The package may have incorrect main/module/exports specified in its package.json.

### DIFF
--- a/packages/tiled/src/parser/open-file.ts
+++ b/packages/tiled/src/parser/open-file.ts
@@ -1,6 +1,6 @@
 import { TiledParser } from "./parser"
 import axios from 'axios'
-import fs from 'fs'
+import fs from 'node:fs'
 import { TiledMap } from "../types/Map"
 import { TiledTileset } from "../types/Tileset"
 import path from "path"


### PR DESCRIPTION
Yikes

X [ERROR] Failed to resolve entry for package "fs". The package may have incorrect main/module/exports specified in its package.json. [plugin vite:dep-pre-bundle]

    node_modules/esbuild/lib/main.js:1360:21:
      1360 │         let result = await callback({
           ╵                      ^

    at packageEntryFailure (file:///C:/Users/GGLVXD/Documents/Frostleria/node_modules/vite/dist/node/chunks/dep-4d3eff22.js:23382:11)
    at resolvePackageEntry (file:///C:/Users/GGLVXD/Documents/Frostleria/node_modules/vite/dist/node/chunks/dep-4d3eff22.js:23379:5)
    at tryNodeResolve (file:///C:/Users/GGLVXD/Documents/Frostleria/node_modules/vite/dist/node/chunks/dep-4d3eff22.js:23113:20)
    at Context.resolveId (file:///C:/Users/GGLVXD/Documents/Frostleria/node_modules/vite/dist/node/chunks/dep-4d3eff22.js:22874:28)
    at Object.resolveId (file:///C:/Users/GGLVXD/Documents/Frostleria/node_modules/vite/dist/node/chunks/dep-4d3eff22.js:42847:46)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at file:///C:/Users/GGLVXD/Documents/Frostleria/node_modules/vite/dist/node/chunks/dep-4d3eff22.js:64148:21
    at file:///C:/Users/GGLVXD/Documents/Frostleria/node_modules/vite/dist/node/chunks/dep-4d3eff22.js:23689:34
    at requestCallbacks.on-resolve (C:\Users\GGLVXD\Documents\Frostleria\node_modules\esbuild\lib\main.js:1360:22)
    at handleRequest (C:\Users\GGLVXD\Documents\Frostleria\node_modules\esbuild\lib\main.js:723:13)

  This error came from the "onResolve" callback registered here:

    node_modules/esbuild/lib/main.js:1279:20:
      1279 │       let promise = setup({
           ╵                     ^

    at setup (file:///C:/Users/GGLVXD/Documents/Frostleria/node_modules/vite/dist/node/chunks/dep-4d3eff22.js:23669:19)
    at handlePlugins (C:\Users\GGLVXD\Documents\Frostleria\node_modules\esbuild\lib\main.js:1279:21)
    at buildOrContextImpl (C:\Users\GGLVXD\Documents\Frostleria\node_modules\esbuild\lib\main.js:968:5)
    at Object.buildOrContext (C:\Users\GGLVXD\Documents\Frostleria\node_modules\esbuild\lib\main.js:776:5)
    at C:\Users\GGLVXD\Documents\Frostleria\node_modules\esbuild\lib\main.js:2172:68
    at new Promise (<anonymous>)
    at Object.context (C:\Users\GGLVXD\Documents\Frostleria\node_modules\esbuild\lib\main.js:2172:27)
    at Object.context (C:\Users\GGLVXD\Documents\Frostleria\node_modules\esbuild\lib\main.js:2012:58)
    at prepareEsbuildOptimizerRun (file:///C:/Users/GGLVXD/Documents/Frostleria/node_modules/vite/dist/node/chunks/dep-4d3eff22.js:44450:35)

  The plugin "vite:dep-pre-bundle" was triggered by this import

    node_modules/@rpgjs/tiled/lib/parser/open-file.js:3:15:
      3 │ import fs from 'fs';
        ╵                ~~~~

4:43:03 PM [vite] error while updating dependencies:
Error: Build failed with 1 error:
node_modules/esbuild/lib/main.js:1360:21: ERROR: [plugin: vite:dep-pre-bundle] Failed to resolve entry for package "fs". The package may have incorrect main/module/exports specified in its package.json.
    at failureErrorWithLog (C:\Users\GGLVXD\Documents\Frostleria\node_modules\esbuild\lib\main.js:1636:15)
    at C:\Users\GGLVXD\Documents\Frostleria\node_modules\esbuild\lib\main.js:1048:25
    at C:\Users\GGLVXD\Documents\Frostleria\node_modules\esbuild\lib\main.js:1512:9
    at processTicksAndRejections (node:internal/process/task_queues:95:5)