### PR TITLE
feat: add optional chat module

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -37,6 +37,7 @@ const guiMenu = [{
   items: [
     { text: "Engine Injection", link: "/gui/engine-injection" },
     { text: "Dialog Box", link: "/gui/dialog-box" },
+    { text: "Chat", link: "/gui/chat" },
     { text: "Vue Integration", link: "/gui/vue-integration" },
     { text: "Optimistic Actions", link: "/gui/optimistic-actions" }
   ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -95,6 +95,7 @@
               "gui/index",
               "gui/title-screen",
               "gui/dialog-box",
+              "gui/chat",
               "gui/hud",
               "gui/prebuilt-contracts",
               "guide/gui/attach-gui",

--- a/docs/gui/chat.md
+++ b/docs/gui/chat.md
@@ -1,0 +1,99 @@
+---
+title: "Chat"
+description: "Install the optional RPGJS MMORPG chat module."
+---
+
+# Chat
+
+`@rpgjs/chat` is an optional MMORPG module that adds a map-local chat GUI.
+The client renders a CanvasEngine GUI and sends chat intents to the server.
+The server remains authoritative: it validates each message and broadcasts it
+only to players on the sender's current map.
+
+## Installation
+
+Install the package in your game and import the shared UI CSS once in your
+client entry or client config.
+
+```ts
+import "@rpgjs/ui-css/index.css";
+import "@rpgjs/ui-css/theme-default.css";
+```
+
+Register the client module:
+
+```ts
+import { provideChat } from "@rpgjs/chat/client";
+
+export default {
+  providers: [
+    provideChat()
+  ]
+};
+```
+
+Register the server module:
+
+```ts
+import { provideChat } from "@rpgjs/chat/server";
+
+provideServerModules([
+  provideChat()
+]);
+```
+
+With the default options, the chat opens automatically when the current player
+is available. Messages are sent on `chat:send` and received on `chat:message`.
+
+## Options
+
+Client options:
+
+```ts
+provideChat({
+  autoOpen: true,
+  position: "bottom-left",
+  maxMessages: 100,
+  placeholder: "Message..."
+});
+```
+
+Server options:
+
+```ts
+provideChat({
+  maxLength: 180,
+  formatAuthor(player) {
+    return player.name || `Player ${player.id}`;
+  },
+  sanitize(text, player) {
+    if (text.startsWith("/")) return false;
+    return text;
+  }
+});
+```
+
+`sanitize()` can return a modified string or `false` to reject the message.
+After sanitization, empty messages are rejected and long messages are clipped to
+`maxLength`.
+
+## Message Shape
+
+```ts
+type ChatMessage = {
+  id: string;
+  text: string;
+  author: string;
+  playerId: string;
+  mapId: string;
+  createdAt: number;
+  scope: "map";
+};
+```
+
+## Scope
+
+The first version is deliberately small: it supports map-local MMORPG chat.
+Global chat, private messages, party/guild channels, persisted history, slash
+commands, and speech bubbles can be added by extending the same transport and
+GUI patterns later.

--- a/docs/gui/index.md
+++ b/docs/gui/index.md
@@ -15,6 +15,7 @@ Use GUI when the player interacts with an interface, when the server opens a men
 | --- | --- |
 | Show a start screen before the player enters the game | [Title Screen](/gui/title-screen) |
 | Display conversations or narrative text | [Dialog Box](/gui/dialog-box) |
+| Add map-local MMORPG player chat | [Chat](/gui/chat) |
 | Show persistent game information on screen | [HUD](/gui/hud) |
 | Replace a prebuilt GUI with your own component | [Prebuilt GUI Contracts](/gui/prebuilt-contracts) |
 | Attach an interactive interface to a sprite | [Attach GUI to Sprites](/guide/gui/attach-gui) |

--- a/packages/chat/CHANGELOG.md
+++ b/packages/chat/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @rpgjs/chat
+
+## 5.0.0-beta.0
+
+### Minor Changes
+
+- Add the optional map-local MMORPG chat module with CanvasEngine GUI, server-side validation, and `@rpgjs/ui-css` styles.

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@rpgjs/chat",
+  "version": "5.0.0-beta.0",
+  "main": "dist/client/index.js",
+  "types": "dist/client/index.d.ts",
+  "scripts": {
+    "dev": "vite build --watch",
+    "build": "vite build",
+    "test": "vitest --environment jsdom"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/client/index.js",
+      "types": "./dist/client/index.d.ts"
+    },
+    "./client": {
+      "import": "./dist/client/index.js",
+      "types": "./dist/client/index.d.ts"
+    },
+    "./server": {
+      "import": "./dist/server/index.js",
+      "types": "./dist/server/index.d.ts"
+    }
+  },
+  "keywords": [
+    "rpg",
+    "mmorpg",
+    "chat",
+    "rpgjs"
+  ],
+  "author": "",
+  "license": "MIT",
+  "description": "Optional map-local MMORPG chat module for RPGJS",
+  "peerDependencies": {
+    "@rpgjs/client": "workspace:*",
+    "@rpgjs/common": "workspace:*",
+    "@rpgjs/server": "workspace:*",
+    "@rpgjs/vite": "workspace:*",
+    "canvasengine": "^2.0.0-rc.4"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@canvasengine/compiler": "2.0.0-rc.4",
+    "vite": "^8.0.13",
+    "vite-plugin-dts": "^5.0.0",
+    "vitest": "^4.1.6"
+  },
+  "type": "module"
+}

--- a/packages/chat/src/client-state.spec.ts
+++ b/packages/chat/src/client-state.spec.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { normalizeChatOptions } from "./config";
+import {
+  addChatMessage,
+  chatMessages,
+  clearChatMessages,
+  configureChatClient,
+} from "./client-state";
+import type { ChatMessage } from "./types";
+
+const message = (id: string): ChatMessage => ({
+  id,
+  text: `message ${id}`,
+  author: "Ada",
+  playerId: "player-1",
+  mapId: "map-1",
+  createdAt: Number(id),
+  scope: "map",
+});
+
+describe("chat client state", () => {
+  beforeEach(() => {
+    configureChatClient(normalizeChatOptions({ maxMessages: 2 }));
+  });
+
+  test("adds received messages", () => {
+    addChatMessage(message("1"));
+
+    expect(chatMessages()).toEqual([message("1")]);
+  });
+
+  test("keeps only maxMessages entries", () => {
+    addChatMessage(message("1"));
+    addChatMessage(message("2"));
+    addChatMessage(message("3"));
+
+    expect(chatMessages()).toEqual([message("2"), message("3")]);
+  });
+
+  test("clears messages", () => {
+    addChatMessage(message("1"));
+    clearChatMessages();
+
+    expect(chatMessages()).toEqual([]);
+  });
+});

--- a/packages/chat/src/client-state.ts
+++ b/packages/chat/src/client-state.ts
@@ -1,0 +1,21 @@
+import { signal } from "canvasengine";
+import type { ChatMessage, ResolvedChatOptions } from "./types";
+import { DEFAULT_CHAT_OPTIONS } from "./config";
+
+export const chatMessages = signal<ChatMessage[]>([]);
+export const chatOptions = signal<ResolvedChatOptions>(DEFAULT_CHAT_OPTIONS);
+
+export function configureChatClient(options: ResolvedChatOptions) {
+  chatOptions.set(options);
+  chatMessages.set([]);
+}
+
+export function addChatMessage(message: ChatMessage) {
+  const maxMessages = chatOptions().maxMessages;
+  const nextMessages = [...chatMessages(), message];
+  chatMessages.set(nextMessages.slice(Math.max(0, nextMessages.length - maxMessages)));
+}
+
+export function clearChatMessages() {
+  chatMessages.set([]);
+}

--- a/packages/chat/src/client.ts
+++ b/packages/chat/src/client.ts
@@ -1,0 +1,90 @@
+import {
+  inject,
+  RpgClientEngine,
+  RpgGui,
+  WebSocketToken,
+  type AbstractWebsocket,
+  type RpgClient,
+} from "@rpgjs/client";
+import { createModule, defineModule } from "@rpgjs/common";
+import {
+  CHAT_MESSAGE_EVENT,
+  CHAT_SEND_EVENT,
+  getChatOptions,
+  normalizeChatOptions,
+  setChatOptions,
+} from "./config";
+import {
+  addChatMessage,
+  configureChatClient,
+} from "./client-state";
+import type { ChatClientOptions, ChatMessage, ChatOptions } from "./types";
+// @ts-ignore CanvasEngine components are compiled by @canvasengine/compiler.
+import ChatComponent from "./components/chat.ce";
+
+const boundSockets = new WeakSet<AbstractWebsocket>();
+
+export function createChatClient(options: ChatClientOptions = {}) {
+  const normalized = normalizeChatOptions(options);
+  setChatOptions(normalized);
+  configureChatClient(normalized);
+
+  const module = defineModule<RpgClient>({
+    gui: [
+      {
+        id: normalized.guiId,
+        component: ChatComponent,
+        autoDisplay: normalized.autoOpen,
+        data: {
+          placeholder: normalized.placeholder,
+          position: normalized.position,
+        },
+        dependencies: () => {
+          const engine = inject(RpgClientEngine);
+          return [engine.scene.currentPlayer];
+        },
+      },
+    ],
+    engine: {
+      onConnected() {
+        const socket = inject<AbstractWebsocket>(WebSocketToken);
+        if (boundSockets.has(socket)) return;
+        boundSockets.add(socket);
+        socket.on(CHAT_MESSAGE_EVENT, (message: ChatMessage) => {
+          addChatMessage(message);
+        });
+      },
+    },
+  });
+
+  return module;
+}
+
+export function provideChat(options: ChatOptions = {}) {
+  return createModule("Chat", [
+    {
+      client: createChatClient(options),
+    },
+  ]);
+}
+
+export function sendChatMessage(text: string) {
+  const socket = inject<AbstractWebsocket>(WebSocketToken);
+  socket.emit(CHAT_SEND_EVENT, { text });
+}
+
+export function openChat() {
+  const gui = inject(RpgGui);
+  gui.display(getChatOptions().guiId);
+}
+
+export { ChatComponent };
+export {
+  addChatMessage,
+  chatMessages,
+  chatOptions,
+  clearChatMessages,
+  configureChatClient,
+} from "./client-state";
+
+export default createChatClient();

--- a/packages/chat/src/components/chat.ce
+++ b/packages/chat/src/components/chat.ce
@@ -1,0 +1,56 @@
+<DOMContainer width="100%" height="100%" class="rpg-chat-root">
+  <section class="rpg-ui-chat rpg-ui-panel" data-position={position()}>
+    <div class="rpg-ui-chat-log">
+      @for (message of visibleMessages) {
+        <div class="rpg-ui-chat-message" data-player-id={message.playerId}>
+          <span class="rpg-ui-chat-author">{message.author}</span>
+          <span class="rpg-ui-chat-text">{message.text}</span>
+        </div>
+      }
+    </div>
+    <form class="rpg-ui-chat-form" submit={submitMessage}>
+      <input
+        class="rpg-ui-input rpg-ui-chat-input"
+        type="text"
+        maxlength={maxLength()}
+        placeholder={placeholder()}
+        value={draft()}
+        input={onInput}
+      />
+      <button class="rpg-ui-button rpg-ui-chat-send" type="submit" disabled={isEmpty()}>
+        Send
+      </button>
+    </form>
+  </section>
+</DOMContainer>
+
+<script>
+  import { computed, signal } from "canvasengine";
+  import { inject, WebSocketToken } from "@rpgjs/client";
+  import { CHAT_SEND_EVENT } from "../config";
+  import { chatMessages, chatOptions } from "../client-state";
+
+  const { data } = defineProps();
+  const socket = inject(WebSocketToken);
+  const draft = signal("");
+
+  const resolveProp = (value) => typeof value === "function" ? value() : value;
+  const providedData = computed(() => resolveProp(data) || {});
+  const placeholder = computed(() => providedData().placeholder || chatOptions().placeholder);
+  const position = computed(() => providedData().position || chatOptions().position);
+  const maxLength = computed(() => chatOptions().maxLength);
+  const visibleMessages = computed(() => chatMessages());
+  const isEmpty = computed(() => draft().trim().length === 0);
+
+  const onInput = (event) => {
+    draft.set(event.target?.value || "");
+  };
+
+  const submitMessage = (event) => {
+    event.preventDefault();
+    const text = draft().trim();
+    if (!text) return;
+    socket.emit(CHAT_SEND_EVENT, { text });
+    draft.set("");
+  };
+</script>

--- a/packages/chat/src/config.ts
+++ b/packages/chat/src/config.ts
@@ -1,0 +1,48 @@
+import type { ChatOptions, ResolvedChatOptions } from "./types";
+
+export const CHAT_GUI_ID = "rpg-chat";
+export const CHAT_SEND_EVENT = "chat:send";
+export const CHAT_MESSAGE_EVENT = "chat:message";
+
+export const DEFAULT_CHAT_OPTIONS: ResolvedChatOptions = {
+  guiId: CHAT_GUI_ID,
+  autoOpen: true,
+  position: "bottom-left",
+  maxMessages: 100,
+  maxLength: 180,
+  placeholder: "Message...",
+  formatAuthor: (player) => player.name || `Player ${player.id}`,
+};
+
+let currentChatOptions: ResolvedChatOptions = DEFAULT_CHAT_OPTIONS;
+
+const positiveInteger = (
+  value: number | undefined,
+  fallback: number
+): number => {
+  if (!Number.isFinite(value) || value === undefined) return fallback;
+  return Math.max(1, Math.floor(value));
+};
+
+export function normalizeChatOptions(
+  options: ChatOptions = {}
+): ResolvedChatOptions {
+  return {
+    ...DEFAULT_CHAT_OPTIONS,
+    ...options,
+    maxMessages: positiveInteger(
+      options.maxMessages,
+      DEFAULT_CHAT_OPTIONS.maxMessages
+    ),
+    maxLength: positiveInteger(options.maxLength, DEFAULT_CHAT_OPTIONS.maxLength),
+    formatAuthor: options.formatAuthor ?? DEFAULT_CHAT_OPTIONS.formatAuthor,
+  };
+}
+
+export function setChatOptions(options: ResolvedChatOptions) {
+  currentChatOptions = options;
+}
+
+export function getChatOptions(): ResolvedChatOptions {
+  return currentChatOptions;
+}

--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -1,0 +1,53 @@
+import client, {
+  createChatClient,
+  openChat,
+  sendChatMessage,
+} from "./client";
+import server, {
+  createChatServer,
+  createMapChatMessage,
+  handleChatSend,
+} from "./server";
+import { createModule } from "@rpgjs/common";
+import type { ChatOptions } from "./types";
+
+export {
+  CHAT_GUI_ID,
+  CHAT_MESSAGE_EVENT,
+  CHAT_SEND_EVENT,
+  DEFAULT_CHAT_OPTIONS,
+  getChatOptions,
+  normalizeChatOptions,
+} from "./config";
+export {
+  createChatClient,
+  openChat,
+  sendChatMessage,
+  createChatServer,
+  createMapChatMessage,
+  handleChatSend,
+};
+export type {
+  ChatClientOptions,
+  ChatMessage,
+  ChatMessagePayload,
+  ChatPlayerLike,
+  ChatOptions,
+  ChatPosition,
+  ChatServerOptions,
+  ResolvedChatOptions,
+} from "./types";
+
+export function provideChat(options: ChatOptions = {}) {
+  return createModule("Chat", [
+    {
+      server: createChatServer?.(options),
+      client: createChatClient?.(options),
+    },
+  ]);
+}
+
+export default {
+  server,
+  client,
+};

--- a/packages/chat/src/server.spec.ts
+++ b/packages/chat/src/server.spec.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  CHAT_MESSAGE_EVENT,
+  normalizeChatOptions,
+} from "./config";
+import {
+  createMapChatMessage,
+  handleChatSend,
+} from "./server";
+
+const createPlayer = (overrides: Record<string, any> = {}) => {
+  const map = {
+    id: "map-1",
+    broadcast: vi.fn(),
+  };
+  const player = {
+    id: "player-1",
+    name: "Ada",
+    getCurrentMap: vi.fn(() => map),
+    ...overrides,
+  };
+  return { player: player as any, map };
+};
+
+describe("chat server", () => {
+  test("rejects empty messages", async () => {
+    const { player } = createPlayer();
+    const options = normalizeChatOptions();
+
+    await expect(
+      createMapChatMessage(player, { text: "   " }, options)
+    ).resolves.toBeNull();
+  });
+
+  test("trims whitespace and clips to maxLength", async () => {
+    const { player } = createPlayer();
+    const options = normalizeChatOptions({ maxLength: 8 });
+
+    const message = await createMapChatMessage(
+      player,
+      { text: "  hello     world  " },
+      options
+    );
+
+    expect(message).toMatchObject({
+      text: "hello wo",
+      author: "Ada",
+      playerId: "player-1",
+      mapId: "map-1",
+      scope: "map",
+    });
+    expect(typeof message?.id).toBe("string");
+    expect(typeof message?.createdAt).toBe("number");
+  });
+
+  test("uses sanitize to reject a message", async () => {
+    const { player } = createPlayer();
+    const options = normalizeChatOptions({
+      sanitize: () => false,
+    });
+
+    await expect(
+      createMapChatMessage(player, { text: "blocked" }, options)
+    ).resolves.toBeNull();
+  });
+
+  test("uses sanitize to transform a message", async () => {
+    const { player } = createPlayer();
+    const options = normalizeChatOptions({
+      sanitize: (text) => text.replace("bad", "ok"),
+    });
+
+    const message = await createMapChatMessage(
+      player,
+      { text: "bad message" },
+      options
+    );
+
+    expect(message?.text).toBe("ok message");
+  });
+
+  test("broadcasts accepted messages on the current map", async () => {
+    const { player, map } = createPlayer();
+    const options = normalizeChatOptions();
+
+    const message = await handleChatSend(player, { text: "hello" }, options);
+
+    expect(message?.text).toBe("hello");
+    expect(map.broadcast).toHaveBeenCalledWith(CHAT_MESSAGE_EVENT, message);
+  });
+
+  test("does not broadcast when the player is not on a map", async () => {
+    const { player, map } = createPlayer({
+      getCurrentMap: vi.fn(() => undefined),
+    });
+    const options = normalizeChatOptions();
+
+    await expect(
+      handleChatSend(player, { text: "hello" }, options)
+    ).resolves.toBeNull();
+    expect(map.broadcast).not.toHaveBeenCalled();
+  });
+});

--- a/packages/chat/src/server.ts
+++ b/packages/chat/src/server.ts
@@ -1,0 +1,96 @@
+import { createModule, defineModule } from "@rpgjs/common";
+import type { RpgServer } from "@rpgjs/server";
+import {
+  CHAT_SEND_EVENT,
+  CHAT_MESSAGE_EVENT,
+  normalizeChatOptions,
+  setChatOptions,
+} from "./config";
+import type {
+  ChatMessage,
+  ChatMessagePayload,
+  ChatOptions,
+  ChatPlayerLike,
+  ChatServerOptions,
+  ResolvedChatOptions,
+} from "./types";
+
+const createChatMessageId = () =>
+  globalThis.crypto?.randomUUID?.() || `${Date.now()}-${Math.random()}`;
+
+const resolveMapId = (map: any) => {
+  if (!map) return "";
+  if (typeof map.id === "function") return map.id();
+  return map.id ?? "";
+};
+
+export async function createMapChatMessage(
+  player: ChatPlayerLike,
+  payload: ChatMessagePayload,
+  options: ResolvedChatOptions
+): Promise<ChatMessage | null> {
+  const rawText = typeof payload?.text === "string" ? payload.text : "";
+  let text = rawText.trim().replace(/\s+/g, " ");
+  if (!text) return null;
+  if (text.length > options.maxLength) {
+    text = text.slice(0, options.maxLength);
+  }
+  if (options.sanitize) {
+    const sanitized = await options.sanitize(text, player);
+    if (sanitized === false) return null;
+    text = sanitized.trim().replace(/\s+/g, " ");
+    if (!text) return null;
+    if (text.length > options.maxLength) {
+      text = text.slice(0, options.maxLength);
+    }
+  }
+
+  const map = player.getCurrentMap();
+  if (!map) return null;
+
+  return {
+    id: createChatMessageId(),
+    text,
+    author: options.formatAuthor(player),
+    playerId: player.id,
+    mapId: resolveMapId(map),
+    createdAt: Date.now(),
+    scope: "map",
+  };
+}
+
+export async function handleChatSend(
+  player: ChatPlayerLike,
+  payload: ChatMessagePayload,
+  options: ResolvedChatOptions
+): Promise<ChatMessage | null> {
+  const message = await createMapChatMessage(player, payload, options);
+  if (!message) return null;
+  player.getCurrentMap()?.broadcast(CHAT_MESSAGE_EVENT, message);
+  return message;
+}
+
+export function createChatServer(options: ChatServerOptions = {}) {
+  const normalized = normalizeChatOptions(options);
+  setChatOptions(normalized);
+
+  return defineModule<RpgServer>({
+    player: {
+      onConnected(player) {
+        player.on(CHAT_SEND_EVENT, async (payload) => {
+          await handleChatSend(player, payload, normalized);
+        });
+      },
+    },
+  });
+}
+
+export function provideChat(options: ChatOptions = {}) {
+  return createModule("Chat", [
+    {
+      server: createChatServer(options),
+    },
+  ]);
+}
+
+export default createChatServer();

--- a/packages/chat/src/types.ts
+++ b/packages/chat/src/types.ts
@@ -1,0 +1,55 @@
+export type ChatPosition =
+  | "bottom-left"
+  | "bottom-right"
+  | "top-left"
+  | "top-right";
+
+export interface ChatPlayerLike {
+  id: string;
+  name?: string;
+  getCurrentMap(): any;
+}
+
+export interface ChatMessage {
+  id: string;
+  text: string;
+  author: string;
+  playerId: string;
+  mapId: string;
+  createdAt: number;
+  scope: "map";
+}
+
+export interface ChatMessagePayload {
+  text?: unknown;
+}
+
+export interface ChatClientOptions {
+  guiId?: string;
+  autoOpen?: boolean;
+  position?: ChatPosition;
+  maxMessages?: number;
+  placeholder?: string;
+}
+
+export interface ChatServerOptions {
+  maxLength?: number;
+  sanitize?: (
+    text: string,
+    player: ChatPlayerLike
+  ) => string | false | Promise<string | false>;
+  formatAuthor?: (player: ChatPlayerLike) => string;
+}
+
+export interface ChatOptions extends ChatClientOptions, ChatServerOptions {}
+
+export interface ResolvedChatOptions {
+  guiId: string;
+  autoOpen: boolean;
+  position: ChatPosition;
+  maxMessages: number;
+  maxLength: number;
+  placeholder: string;
+  sanitize?: ChatServerOptions["sanitize"];
+  formatAuthor: (player: ChatPlayerLike) => string;
+}

--- a/packages/chat/vite.config.ts
+++ b/packages/chat/vite.config.ts
@@ -1,0 +1,3 @@
+import { rpgjsModuleViteConfig } from "@rpgjs/vite";
+
+export default rpgjsModuleViteConfig();

--- a/packages/ui-css/src/index.css
+++ b/packages/ui-css/src/index.css
@@ -18,6 +18,7 @@
 @import './primitives/hotbar.css';
 @import './primitives/tooltip.css';
 @import './primitives/toast.css';
+@import './primitives/chat.css';
 @import './primitives/title-screen.css';
 @import './primitives/gameover.css';
 @import './primitives/hud.css';

--- a/packages/ui-css/src/primitives/chat.css
+++ b/packages/ui-css/src/primitives/chat.css
@@ -1,0 +1,94 @@
+.rpg-chat-root {
+  pointer-events: none;
+}
+
+.rpg-ui-chat {
+  position: fixed;
+  width: min(420px, calc(100vw - 24px));
+  height: min(260px, 42vh);
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: var(--rpg-ui-spacing-sm);
+  pointer-events: auto;
+  z-index: 1200;
+}
+
+.rpg-ui-chat[data-position="bottom-left"] {
+  left: 12px;
+  bottom: 12px;
+}
+
+.rpg-ui-chat[data-position="bottom-right"] {
+  right: 12px;
+  bottom: 12px;
+}
+
+.rpg-ui-chat[data-position="top-left"] {
+  left: 12px;
+  top: 12px;
+}
+
+.rpg-ui-chat[data-position="top-right"] {
+  right: 12px;
+  top: 12px;
+}
+
+.rpg-ui-chat-log {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-right: 4px;
+}
+
+.rpg-ui-chat-message {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  font-size: var(--rpg-ui-font-size-sm);
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.rpg-ui-chat-author {
+  flex: 0 0 auto;
+  color: var(--rpg-ui-accent);
+  font-weight: 700;
+}
+
+.rpg-ui-chat-author::after {
+  content: ":";
+}
+
+.rpg-ui-chat-text {
+  color: var(--rpg-ui-text);
+}
+
+.rpg-ui-chat-form {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--rpg-ui-spacing-sm);
+  align-items: center;
+}
+
+.rpg-ui-chat-input {
+  min-width: 0;
+}
+
+.rpg-ui-chat-send {
+  white-space: nowrap;
+}
+
+@media (max-width: 520px) {
+  .rpg-ui-chat {
+    left: 8px;
+    right: 8px;
+    bottom: 8px;
+    top: auto;
+    width: auto;
+    height: min(220px, 38vh);
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,37 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0(@microsoft/api-extractor@7.52.3(@types/node@25.8.0))(esbuild@0.28.0)(rolldown@1.0.1)(typescript@6.0.3)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(tsx@4.22.0)(yaml@2.8.3))
 
+  packages/chat:
+    dependencies:
+      '@rpgjs/client':
+        specifier: workspace:*
+        version: link:../client
+      '@rpgjs/common':
+        specifier: workspace:*
+        version: link:../common
+      '@rpgjs/server':
+        specifier: workspace:*
+        version: link:../server
+      '@rpgjs/vite':
+        specifier: workspace:*
+        version: link:../vite
+      canvasengine:
+        specifier: ^2.0.0-rc.4
+        version: 2.0.0-rc.4(@types/react@19.2.14)(pixi.js@8.18.1)(react@19.2.6)
+    devDependencies:
+      '@canvasengine/compiler':
+        specifier: 2.0.0-rc.4
+        version: 2.0.0-rc.4(@types/node@25.8.0)(esbuild@0.28.0)(tsx@4.22.0)(yaml@2.8.3)
+      vite:
+        specifier: ^8.0.13
+        version: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(tsx@4.22.0)(yaml@2.8.3)
+      vite-plugin-dts:
+        specifier: ^5.0.0
+        version: 5.0.0(@microsoft/api-extractor@7.52.3(@types/node@25.8.0))(esbuild@0.28.0)(rolldown@1.0.1)(typescript@6.0.3)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(tsx@4.22.0)(yaml@2.8.3))
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.6(@types/node@25.8.0)(jsdom@29.1.1)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(tsx@4.22.0)(yaml@2.8.3))
+
   packages/client:
     dependencies:
       '@canvasengine/presets':


### PR DESCRIPTION
## Summary

Adds an optional `@rpgjs/chat` module for map-local MMORPG chat.

The module provides:

- a server-side `chat:send` handler that validates/sanitizes player messages and broadcasts accepted messages to the sender's current map
- a CanvasEngine chat GUI registered by the client module
- shared chat state helpers and options
- `@rpgjs/ui-css` chat primitive styles
- documentation under the GUI section

## Notes

This PR does not include the v5 stable-release proposal Markdown document. That local proposal file was removed before publishing, so this PR only contains the chat feature branch changes.

## Validation

- `pnpm --dir packages/chat test -- --run`
- `pnpm --dir packages/chat build` *(completed with exit code 0; Vite DTS emitted existing TypeScript diagnostics from `packages/common` during declaration generation)*
- `pnpm --dir docs validate`
