### PR TITLE
fix(client): guard camera follow during map changes

### DIFF
--- a/.changeset/calm-cameras-switch.md
+++ b/.changeset/calm-cameras-switch.md
@@ -1,0 +1,5 @@
+---
+"@rpgjs/client": patch
+---
+
+Guard camera follow targets during map changes to avoid stale sprite crashes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,3 @@
 View content of CONTRIBUTING.md
+
+If released, switch to the next beta version (except for the physic package). On npm, the latest version should be this beta version

--- a/docs/api/client/rpg-client-engine.md
+++ b/docs/api/client/rpg-client-engine.md
@@ -1116,14 +1116,16 @@ object directly to `engine.interactions.use(...)`.
 Set the camera to follow a specific sprite
 
 This method changes which sprite the camera viewport should follow.
-The camera will smoothly animate to the target sprite if smoothMove options are provided.
+The camera can smoothly animate to the target sprite before continuous follow starts.
 
 ## Design
 
 The camera follow target is stored in a signal that is read by sprite components.
 Each sprite checks if it should be followed by comparing its ID with the target ID.
 When smoothMove options are provided, the viewport animation is handled by CanvasEngine's
-viewport system.
+viewport system. `time` and `ease` configure the transition to the target, while
+`speed`, `acceleration`, and `radius` configure the continuous follow behavior after
+the transition.
 
 - Source: `packages/client/src/RpgClientEngine.ts`
 - Kind: `method`
@@ -1132,13 +1134,20 @@ viewport system.
 ### Signature
 
 ```ts
-setCameraFollow(targetId: string | null, smoothMove?: boolean | { time?: number; ease?: string }): void
+setCameraFollow(targetId: string | null, smoothMove?: boolean | {
+  enabled?: boolean;
+  time?: number;
+  ease?: CameraFollowEase;
+  speed?: number;
+  acceleration?: number | null;
+  radius?: number | null;
+}): void
 ```
 
 ### Parameters
 
 - `targetId`: `string | null`
-- `smoothMove?`: `boolean | { time?: number; ease?: string }`
+- `smoothMove?`: `boolean | { enabled?: boolean; time?: number; ease?: CameraFollowEase; speed?: number; acceleration?: number | null; radius?: number | null }`
 
 ### Examples
 
@@ -1150,6 +1159,15 @@ engine.setCameraFollow(otherPlayerId, true);
 engine.setCameraFollow(eventId, {
   time: 1000,
   ease: "easeInOutQuad"
+});
+
+// Follow with a smooth transition and softer continuous follow
+engine.setCameraFollow(eventId, {
+  time: 1000,
+  ease: "easeInOutQuad",
+  speed: 12,
+  acceleration: 0.2,
+  radius: 80
 });
 
 // Follow without animation (instant)

--- a/docs/api/player/common-commands.md
+++ b/docs/api/player/common-commands.md
@@ -136,7 +136,14 @@ following NPCs, or focusing on specific events.
 
 ```ts
 cameraFollow(otherPlayer: RpgPlayer | RpgEvent, options?: {
-      smoothMove?: boolean | { time?: number; ease?: string };
+      smoothMove?: boolean | {
+        enabled?: boolean;
+        time?: number;
+        ease?: CameraFollowEase;
+        speed?: number;
+        acceleration?: number | null;
+        radius?: number | null;
+      };
     }): void
 ```
 
@@ -144,7 +151,7 @@ cameraFollow(otherPlayer: RpgPlayer | RpgEvent, options?: {
 
 - `otherPlayer`: `RpgPlayer | RpgEvent`
 - `options?`: `{
-      smoothMove?: boolean | { time?: number; ease?: string };
+      smoothMove?: boolean | { enabled?: boolean; time?: number; ease?: CameraFollowEase; speed?: number; acceleration?: number | null; radius?: number | null };
     }`
 
 ### Examples
@@ -158,6 +165,17 @@ player.cameraFollow(npcEvent, {
   smoothMove: {
     time: 1000,
     ease: "easeInOutQuad"
+  }
+});
+
+// Follow with a smooth transition and softer continuous follow
+player.cameraFollow(npcEvent, {
+  smoothMove: {
+    time: 1000,
+    ease: "easeInOutQuad",
+    speed: 12,
+    acceleration: 0.2,
+    radius: 80
   }
 });
 

--- a/packages/client/src/RpgClientEngine.ts
+++ b/packages/client/src/RpgClientEngine.ts
@@ -41,6 +41,12 @@ import { RpgClientInteractions } from "./services/interactions";
 import { normalizeRoomMapId } from "./utils/mapId";
 import { EventComponentResolverRegistry, type EventComponentResolver } from "./Game/EventComponentResolver";
 import { RpgClientBuiltinI18n } from "./i18n";
+import type { CameraFollowSmoothMove } from "./services/cameraFollow";
+export type {
+  CameraFollowEase,
+  CameraFollowSmoothMove,
+  CameraFollowSmoothMoveOptions,
+} from "./services/cameraFollow";
 
 interface MovementTrajectoryPoint {
   frame: number;
@@ -183,6 +189,10 @@ export class RpgClientEngine<T = any> {
   private eventComponentResolvers = new EventComponentResolverRegistry();
   /** ID of the sprite that the camera should follow. null means follow the current player */
   cameraFollowTargetId = signal<string | null>(null);
+  /** Camera follow transition options used by character components when the target changes */
+  cameraFollowSmoothMove: CameraFollowSmoothMove = false;
+  /** Incremented for each camera follow command so repeated commands on the same target are applied */
+  cameraFollowRevision = signal(0);
   /** Trigger for map shake animation */
   mapShakeTrigger: ConfigurableTrigger<MapShakeOptions> = trigger<MapShakeOptions>();
 
@@ -606,6 +616,12 @@ export class RpgClientEngine<T = any> {
     return find((this.canvasApp as any)?.stage);
   }
 
+  private clearCameraFollowViewportPlugins(): void {
+    const viewport = this.findViewportInstance();
+    viewport?.plugins?.remove?.("animate");
+    viewport?.plugins?.remove?.("follow");
+  }
+
   private prepareSyncPayload(data: any): any {
     const payload = { ...(data ?? {}) };
     delete payload.ack;
@@ -881,7 +897,7 @@ export class RpgClientEngine<T = any> {
     this.sceneMap.clearLightSpots();
     this.clearComponentAnimations();
     this.projectiles.setMapId(nextMapId);
-    this.cameraFollowTargetId.set(null);
+    this.resetCameraFollow(false);
     this.sceneMap.reset();
     this.sceneMap.loadPhysic();
   }
@@ -1476,19 +1492,22 @@ export class RpgClientEngine<T = any> {
    * Set the camera to follow a specific sprite
    * 
    * This method changes which sprite the camera viewport should follow.
-   * The camera will smoothly animate to the target sprite if smoothMove options are provided.
+   * The camera can smoothly animate to the target sprite before continuous follow starts.
    * 
    * ## Design
    * 
    * The camera follow target is stored in a signal that is read by sprite components.
    * Each sprite checks if it should be followed by comparing its ID with the target ID.
-   * When smoothMove options are provided, the viewport animation is handled by CanvasEngine's
-   * viewport system.
+   * When smoothMove options are provided, the transition is handled by pixi-viewport's
+   * animation plugin, then continuous follow is handled by CanvasEngine's viewport system.
    * 
    * @param targetId - The ID of the sprite to follow. Set to null to follow the current player
    * @param smoothMove - Animation options. Can be a boolean (default: true) or an object with time and ease
    * @param smoothMove.time - Duration of the animation in milliseconds (optional)
    * @param smoothMove.ease - Easing function name from https://easings.net (optional)
+   * @param smoothMove.speed - Continuous follow speed after the transition (optional)
+   * @param smoothMove.acceleration - Continuous follow acceleration after the transition (optional)
+   * @param smoothMove.radius - Center radius where the target can move without moving the viewport (optional)
    * 
    * @example
    * ```ts
@@ -1510,19 +1529,19 @@ export class RpgClientEngine<T = any> {
    */
   setCameraFollow(
     targetId: string | null,
-    smoothMove?: boolean | { time?: number; ease?: string }
+    smoothMove?: CameraFollowSmoothMove
   ): void {
-    // Store smoothMove options for potential future use with viewport animation
-    // For now, we just set the target ID and let CanvasEngine handle the viewport follow
-    // The smoothMove options could be used to configure viewport animation if CanvasEngine supports it
+    this.clearCameraFollowViewportPlugins();
+    this.cameraFollowSmoothMove = smoothMove ?? true;
     this.cameraFollowTargetId.set(targetId);
-    
-    // If smoothMove is an object, we could store it for viewport configuration
-    // This would require integration with CanvasEngine's viewport animation system
-    if (typeof smoothMove === "object" && smoothMove !== null) {
-      // Future: Apply smoothMove.time and smoothMove.ease to viewport animation
-      // For now, CanvasEngine handles viewport following automatically
-    }
+    this.cameraFollowRevision.set(this.cameraFollowRevision() + 1);
+  }
+
+  private resetCameraFollow(smoothMove: CameraFollowSmoothMove = false): void {
+    this.clearCameraFollowViewportPlugins();
+    this.cameraFollowSmoothMove = smoothMove;
+    this.cameraFollowTargetId.set(null);
+    this.cameraFollowRevision.set(this.cameraFollowRevision() + 1);
   }
 
   addParticle(particle: any) {
@@ -2611,7 +2630,7 @@ export class RpgClientEngine<T = any> {
 
       // Reset signals
       this.playerIdSignal.set(null);
-      this.cameraFollowTargetId.set(null);
+      this.resetCameraFollow(false);
       this.spriteComponentsBehind.set([]);
       this.spriteComponentsInFront.set([]);
       this.eventComponentResolvers.clear();

--- a/packages/client/src/components/character.ce
+++ b/packages/client/src/components/character.ce
@@ -2,7 +2,6 @@
   x={smoothX}
   y={smoothY}
   zIndex={z}
-  viewportFollow={shouldFollowCamera}
   controls
   onBeforeDestroy
   visible
@@ -76,6 +75,7 @@
   import { Particle } from "@canvasengine/presets";
   import { GameEngineToken, ModulesToken, shouldRenderLightingShadows } from "@rpgjs/common";
   import { RpgClientEngine } from "../RpgClientEngine";
+  import { applyCameraFollow, clearCameraFollowPlugins } from "../services/cameraFollow";
   import { inject } from "../core/inject";  
   import { Direction, Animation } from "@rpgjs/common";
   import { normalizeEventComponent } from "../Game/EventComponentResolver";
@@ -1069,6 +1069,31 @@
         client.setKeyboardControls(element.directives.controls)
       }
     })
+
+    effect(() => {
+      if (!shouldFollowCamera()) return;
+
+      const followRevision = client.cameraFollowRevision();
+      const smoothMove = client.cameraFollowSmoothMove;
+      const viewport = element.props.context?.viewport;
+      const target = element.componentInstance;
+      if (!viewport || !target) return;
+
+      applyCameraFollow({
+        viewport,
+        target,
+        smoothMove,
+        followRevision,
+        isCurrentRevision: (revision) => client.cameraFollowRevision() === revision,
+        shouldFollowCamera
+      });
+    })
+
+    return () => {
+      if (shouldFollowCamera()) {
+        clearCameraFollowPlugins(element.props.context?.viewport);
+      }
+    }
   })
 
   /**

--- a/packages/client/src/components/character.ce
+++ b/packages/client/src/components/character.ce
@@ -75,7 +75,7 @@
   import { Particle } from "@canvasengine/presets";
   import { GameEngineToken, ModulesToken, shouldRenderLightingShadows } from "@rpgjs/common";
   import { RpgClientEngine } from "../RpgClientEngine";
-  import { applyCameraFollow, clearCameraFollowPlugins } from "../services/cameraFollow";
+  import { applyCameraFollow, clearCameraFollowPlugins, ownsCameraFollowRevision } from "../services/cameraFollow";
   import { inject } from "../core/inject";  
   import { Direction, Animation } from "@rpgjs/common";
   import { normalizeEventComponent } from "../Game/EventComponentResolver";
@@ -1058,6 +1058,7 @@
   }
 
   mount((element) => {
+    let appliedCameraFollowRevision = null;
     if (typeof document !== 'undefined') {
       document.addEventListener('keydown', handleNativeActionWhileMoving);
       document.addEventListener('keyup', handleNativeActionWhileMoving);
@@ -1071,15 +1072,21 @@
     })
 
     effect(() => {
-      if (!shouldFollowCamera()) return;
-
       const followRevision = client.cameraFollowRevision();
+      if (!shouldFollowCamera()) {
+        appliedCameraFollowRevision = null;
+        return;
+      }
+
       const smoothMove = client.cameraFollowSmoothMove;
       const viewport = element.props.context?.viewport;
       const target = element.componentInstance;
-      if (!viewport || !target) return;
+      if (!viewport || !target) {
+        appliedCameraFollowRevision = null;
+        return;
+      }
 
-      applyCameraFollow({
+      const appliedCameraFollow = applyCameraFollow({
         viewport,
         target,
         smoothMove,
@@ -1087,10 +1094,11 @@
         isCurrentRevision: (revision) => client.cameraFollowRevision() === revision,
         shouldFollowCamera
       });
+      appliedCameraFollowRevision = appliedCameraFollow ? followRevision : null;
     })
 
     return () => {
-      if (shouldFollowCamera()) {
+      if (ownsCameraFollowRevision(appliedCameraFollowRevision, client.cameraFollowRevision())) {
         clearCameraFollowPlugins(element.props.context?.viewport);
       }
     }

--- a/packages/client/src/services/cameraFollow.spec.ts
+++ b/packages/client/src/services/cameraFollow.spec.ts
@@ -3,6 +3,7 @@ import {
   applyCameraFollow,
   cameraFollowAnimationOptions,
   cameraFollowOptions,
+  ownsCameraFollowRevision,
 } from "./cameraFollow";
 
 const createViewport = () => ({
@@ -71,7 +72,11 @@ describe("camera follow", () => {
     const animateOptions = viewport.animate.mock.calls[0][0];
     animateOptions.callbackOnComplete();
 
-    expect(viewport.follow).toHaveBeenCalledWith(target, {
+    const [followTarget, followOptions] = viewport.follow.mock.calls[0];
+    expect(followTarget).not.toBe(target);
+    expect(followTarget.x).toBe(120);
+    expect(followTarget.y).toBe(240);
+    expect(followOptions).toEqual({
       speed: 10,
       radius: 32,
     });
@@ -91,7 +96,10 @@ describe("camera follow", () => {
     });
 
     expect(viewport.animate).not.toHaveBeenCalled();
-    expect(viewport.follow).toHaveBeenCalledWith(target);
+    const [followTarget] = viewport.follow.mock.calls[0];
+    expect(followTarget).not.toBe(target);
+    expect(followTarget.x).toBe(120);
+    expect(followTarget.y).toBe(240);
   });
 
   it("does not follow after animation if another camera command superseded it", () => {
@@ -110,5 +118,103 @@ describe("camera follow", () => {
     animateOptions.callbackOnComplete();
 
     expect(viewport.follow).not.toHaveBeenCalled();
+  });
+
+  it("does not follow a target whose position cannot be read", () => {
+    const viewport = createViewport();
+    const target = {
+      get x(): number {
+        throw new Error("target destroyed");
+      },
+      get y() {
+        return 240;
+      },
+    };
+
+    applyCameraFollow({
+      viewport,
+      target,
+      smoothMove: false,
+      followRevision: 1,
+      isCurrentRevision: () => true,
+      shouldFollowCamera: () => true,
+    });
+
+    expect(viewport.plugins.remove).toHaveBeenCalledWith("animate");
+    expect(viewport.plugins.remove).toHaveBeenCalledWith("follow");
+    expect(viewport.animate).not.toHaveBeenCalled();
+    expect(viewport.follow).not.toHaveBeenCalled();
+  });
+
+  it("keeps the follow target readable when the source target is destroyed", () => {
+    const viewport = createViewport();
+    let position: { x: number; y: number } | null = { x: 120, y: 240 };
+    const target = {
+      get destroyed() {
+        return position === null;
+      },
+      get x() {
+        if (!position) throw new Error("target destroyed");
+        return position.x;
+      },
+      get y() {
+        if (!position) throw new Error("target destroyed");
+        return position.y;
+      },
+    };
+
+    applyCameraFollow({
+      viewport,
+      target,
+      smoothMove: false,
+      followRevision: 1,
+      isCurrentRevision: () => true,
+      shouldFollowCamera: () => true,
+    });
+
+    const [followTarget] = viewport.follow.mock.calls[0];
+    expect(followTarget.x).toBe(120);
+    expect(followTarget.y).toBe(240);
+
+    position = { x: 160, y: 280 };
+    expect(followTarget.x).toBe(160);
+    expect(followTarget.y).toBe(280);
+
+    position = null;
+    expect(followTarget.x).toBe(160);
+    expect(followTarget.y).toBe(280);
+  });
+
+  it("does not follow after animation if the target was destroyed", () => {
+    const viewport = createViewport();
+    let destroyed = false;
+    const target = {
+      get destroyed() {
+        return destroyed;
+      },
+      x: 120,
+      y: 240,
+    };
+
+    applyCameraFollow({
+      viewport,
+      target,
+      smoothMove: { time: 800, ease: "easeInOutQuad" },
+      followRevision: 2,
+      isCurrentRevision: (revision) => revision === 2,
+      shouldFollowCamera: () => true,
+    });
+
+    destroyed = true;
+    const animateOptions = viewport.animate.mock.calls[0][0];
+    animateOptions.callbackOnComplete();
+
+    expect(viewport.follow).not.toHaveBeenCalled();
+  });
+
+  it("only lets the sprite that owns the active follow revision clear plugins", () => {
+    expect(ownsCameraFollowRevision(2, 2)).toBe(true);
+    expect(ownsCameraFollowRevision(2, 3)).toBe(false);
+    expect(ownsCameraFollowRevision(null, 2)).toBe(false);
   });
 });

--- a/packages/client/src/services/cameraFollow.spec.ts
+++ b/packages/client/src/services/cameraFollow.spec.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  applyCameraFollow,
+  cameraFollowAnimationOptions,
+  cameraFollowOptions,
+} from "./cameraFollow";
+
+const createViewport = () => ({
+  animate: vi.fn(),
+  follow: vi.fn(),
+  plugins: {
+    remove: vi.fn(),
+  },
+});
+
+describe("camera follow", () => {
+  it("normalizes transition options from smoothMove", () => {
+    expect(cameraFollowAnimationOptions(true)).toEqual({
+      time: 1000,
+      ease: "easeInOutSine",
+    });
+    expect(cameraFollowAnimationOptions({ time: 450, ease: "easeInOutQuad" })).toEqual({
+      time: 450,
+      ease: "easeInOutQuad",
+    });
+    expect(cameraFollowAnimationOptions({ time: 450, ease: "easeInOutQuadd" } as any)).toEqual({
+      time: 450,
+      ease: "easeInOutSine",
+    });
+    expect(cameraFollowAnimationOptions(false)).toBeNull();
+  });
+
+  it("normalizes continuous follow options", () => {
+    expect(cameraFollowOptions({ speed: 12, acceleration: 0.2, radius: 80 })).toEqual({
+      speed: 12,
+      acceleration: 0.2,
+      radius: 80,
+    });
+    expect(cameraFollowOptions({ speed: -4, acceleration: null, radius: null })).toEqual({
+      speed: 0,
+      acceleration: null,
+      radius: null,
+    });
+    expect(cameraFollowOptions(true)).toBeUndefined();
+  });
+
+  it("animates to the target then follows it", () => {
+    const viewport = createViewport();
+    const target = { x: 120, y: 240 };
+
+    applyCameraFollow({
+      viewport,
+      target,
+      smoothMove: { time: 800, ease: "easeInOutQuad", speed: 10, radius: 32 },
+      followRevision: 2,
+      isCurrentRevision: (revision) => revision === 2,
+      shouldFollowCamera: () => true,
+    });
+
+    expect(viewport.plugins.remove).toHaveBeenCalledWith("animate");
+    expect(viewport.plugins.remove).toHaveBeenCalledWith("follow");
+    expect(viewport.animate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        position: { x: 120, y: 240 },
+        time: 800,
+        ease: "easeInOutQuad",
+      })
+    );
+    expect(viewport.follow).not.toHaveBeenCalled();
+
+    const animateOptions = viewport.animate.mock.calls[0][0];
+    animateOptions.callbackOnComplete();
+
+    expect(viewport.follow).toHaveBeenCalledWith(target, {
+      speed: 10,
+      radius: 32,
+    });
+  });
+
+  it("follows instantly when smoothMove is disabled", () => {
+    const viewport = createViewport();
+    const target = { x: 120, y: 240 };
+
+    applyCameraFollow({
+      viewport,
+      target,
+      smoothMove: false,
+      followRevision: 1,
+      isCurrentRevision: () => true,
+      shouldFollowCamera: () => true,
+    });
+
+    expect(viewport.animate).not.toHaveBeenCalled();
+    expect(viewport.follow).toHaveBeenCalledWith(target);
+  });
+
+  it("does not follow after animation if another camera command superseded it", () => {
+    const viewport = createViewport();
+
+    applyCameraFollow({
+      viewport,
+      target: { x: 120, y: 240 },
+      smoothMove: { time: 800, ease: "easeInOutQuad" },
+      followRevision: 2,
+      isCurrentRevision: (revision) => revision === 3,
+      shouldFollowCamera: () => true,
+    });
+
+    const animateOptions = viewport.animate.mock.calls[0][0];
+    animateOptions.callbackOnComplete();
+
+    expect(viewport.follow).not.toHaveBeenCalled();
+  });
+});

--- a/packages/client/src/services/cameraFollow.ts
+++ b/packages/client/src/services/cameraFollow.ts
@@ -1,0 +1,155 @@
+export const DEFAULT_CAMERA_FOLLOW_TIME = 1000;
+export const DEFAULT_CAMERA_FOLLOW_EASE = "easeInOutSine";
+
+export const CAMERA_FOLLOW_EASES = [
+  "linear",
+  "easeInQuad",
+  "easeOutQuad",
+  "easeInOutQuad",
+  "easeInCubic",
+  "easeOutCubic",
+  "easeInOutCubic",
+  "easeInQuart",
+  "easeOutQuart",
+  "easeInOutQuart",
+  "easeInQuint",
+  "easeOutQuint",
+  "easeInOutQuint",
+  "easeInSine",
+  "easeOutSine",
+  "easeInOutSine",
+  "easeInExpo",
+  "easeOutExpo",
+  "easeInOutExpo",
+  "easeInCirc",
+  "easeOutCirc",
+  "easeInOutCirc",
+  "easeInElastic",
+  "easeOutElastic",
+  "easeInOutElastic",
+  "easeInBack",
+  "easeOutBack",
+  "easeInOutBack",
+  "easeInBounce",
+  "easeOutBounce",
+  "easeInOutBounce",
+] as const;
+
+export type CameraFollowEase = typeof CAMERA_FOLLOW_EASES[number];
+
+export type CameraFollowSmoothMoveOptions = {
+  /** Enable or disable the smooth transition when options are sent as an object. */
+  enabled?: boolean;
+  /** Duration of the transition to the new camera target, in milliseconds. */
+  time?: number;
+  /** pixi-viewport easing name, for example "easeInOutQuad". */
+  ease?: CameraFollowEase;
+  /** Continuous follow speed after the transition. 0 keeps the target centered instantly. */
+  speed?: number;
+  /** Continuous follow acceleration after the transition. */
+  acceleration?: number | null;
+  /** Center radius where the followed target can move without moving the viewport. */
+  radius?: number | null;
+};
+
+export type CameraFollowSmoothMove = boolean | CameraFollowSmoothMoveOptions;
+
+export interface CameraFollowApplyContext {
+  viewport: any;
+  target: { x: number; y: number };
+  smoothMove: CameraFollowSmoothMove;
+  followRevision: number;
+  isCurrentRevision: (revision: number) => boolean;
+  shouldFollowCamera: () => boolean;
+}
+
+const finiteNumber = (value: unknown, fallback: number) => {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+};
+
+const isCameraFollowEase = (value: unknown): value is CameraFollowEase => {
+  return typeof value === "string" && (CAMERA_FOLLOW_EASES as readonly string[]).includes(value);
+};
+
+export const smoothMoveEnabled = (smoothMove: CameraFollowSmoothMove) => {
+  if (smoothMove === false) return false;
+  if (typeof smoothMove === "object" && smoothMove !== null && smoothMove.enabled === false) {
+    return false;
+  }
+  return true;
+};
+
+export const cameraFollowAnimationOptions = (
+  smoothMove: CameraFollowSmoothMove
+) => {
+  if (!smoothMoveEnabled(smoothMove)) return null;
+  const options = typeof smoothMove === "object" && smoothMove !== null ? smoothMove : {};
+  return {
+    time: Math.max(0, finiteNumber(options.time, DEFAULT_CAMERA_FOLLOW_TIME)),
+    ease: isCameraFollowEase(options.ease) ? options.ease : DEFAULT_CAMERA_FOLLOW_EASE,
+  };
+};
+
+export const cameraFollowOptions = (smoothMove: CameraFollowSmoothMove) => {
+  if (typeof smoothMove !== "object" || smoothMove === null) return undefined;
+  const options: { speed?: number; acceleration?: number | null; radius?: number | null } = {};
+  if (typeof smoothMove.speed === "number" && Number.isFinite(smoothMove.speed)) {
+    options.speed = Math.max(0, smoothMove.speed);
+  }
+  if (typeof smoothMove.acceleration === "number" && Number.isFinite(smoothMove.acceleration)) {
+    options.acceleration = Math.max(0, smoothMove.acceleration);
+  } else if (smoothMove.acceleration === null) {
+    options.acceleration = null;
+  }
+  if (typeof smoothMove.radius === "number" && Number.isFinite(smoothMove.radius)) {
+    options.radius = Math.max(0, smoothMove.radius);
+  } else if (smoothMove.radius === null) {
+    options.radius = null;
+  }
+  return Object.keys(options).length > 0 ? options : undefined;
+};
+
+export const clearCameraFollowPlugins = (viewport: any) => {
+  viewport?.plugins?.remove?.("animate");
+  viewport?.plugins?.remove?.("follow");
+};
+
+export const followCameraInstantly = (
+  viewport: any,
+  target: { x: number; y: number },
+  smoothMove: CameraFollowSmoothMove
+) => {
+  const followOptions = cameraFollowOptions(smoothMove);
+  if (followOptions) {
+    viewport.follow(target, followOptions);
+  } else {
+    viewport.follow(target);
+  }
+};
+
+export const applyCameraFollow = ({
+  viewport,
+  target,
+  smoothMove,
+  followRevision,
+  isCurrentRevision,
+  shouldFollowCamera,
+}: CameraFollowApplyContext) => {
+  clearCameraFollowPlugins(viewport);
+
+  const animationOptions = cameraFollowAnimationOptions(smoothMove);
+  if (!animationOptions || animationOptions.time <= 0) {
+    followCameraInstantly(viewport, target, smoothMove);
+    return;
+  }
+
+  viewport.animate({
+    position: { x: target.x, y: target.y },
+    time: animationOptions.time,
+    ease: animationOptions.ease,
+    callbackOnComplete: () => {
+      if (!isCurrentRevision(followRevision) || !shouldFollowCamera()) return;
+      followCameraInstantly(viewport, target, smoothMove);
+    },
+  });
+};

--- a/packages/client/src/services/cameraFollow.ts
+++ b/packages/client/src/services/cameraFollow.ts
@@ -54,9 +54,20 @@ export type CameraFollowSmoothMoveOptions = {
 
 export type CameraFollowSmoothMove = boolean | CameraFollowSmoothMoveOptions;
 
+export type CameraFollowTarget = {
+  x: number;
+  y: number;
+  destroyed?: boolean;
+} | null | undefined;
+
+export type CameraFollowPosition = {
+  x: number;
+  y: number;
+};
+
 export interface CameraFollowApplyContext {
   viewport: any;
-  target: { x: number; y: number };
+  target: CameraFollowTarget;
   smoothMove: CameraFollowSmoothMove;
   followRevision: number;
   isCurrentRevision: (revision: number) => boolean;
@@ -114,17 +125,69 @@ export const clearCameraFollowPlugins = (viewport: any) => {
   viewport?.plugins?.remove?.("follow");
 };
 
+export const ownsCameraFollowRevision = (
+  appliedRevision: number | null,
+  currentRevision: number
+) => {
+  return appliedRevision !== null && appliedRevision === currentRevision;
+};
+
+export const readCameraFollowPosition = (
+  target: CameraFollowTarget
+): CameraFollowPosition | null => {
+  if (!target) return null;
+
+  try {
+    if (target.destroyed) return null;
+    const x = target.x;
+    const y = target.y;
+    if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+    return { x, y };
+  } catch {
+    return null;
+  }
+};
+
+const createCameraFollowTarget = (
+  target: CameraFollowTarget,
+  initialPosition: CameraFollowPosition
+) => {
+  let lastPosition = initialPosition;
+
+  const readPosition = () => {
+    const nextPosition = readCameraFollowPosition(target);
+    if (nextPosition) {
+      lastPosition = nextPosition;
+    }
+    return lastPosition;
+  };
+
+  return {
+    get x() {
+      return readPosition().x;
+    },
+    get y() {
+      return readPosition().y;
+    },
+  };
+};
+
 export const followCameraInstantly = (
   viewport: any,
-  target: { x: number; y: number },
+  target: CameraFollowTarget,
   smoothMove: CameraFollowSmoothMove
 ) => {
+  const position = readCameraFollowPosition(target);
+  if (!position) return false;
+
+  const followTarget = createCameraFollowTarget(target, position);
   const followOptions = cameraFollowOptions(smoothMove);
   if (followOptions) {
-    viewport.follow(target, followOptions);
+    viewport.follow(followTarget, followOptions);
   } else {
-    viewport.follow(target);
+    viewport.follow(followTarget);
   }
+  return true;
 };
 
 export const applyCameraFollow = ({
@@ -137,19 +200,23 @@ export const applyCameraFollow = ({
 }: CameraFollowApplyContext) => {
   clearCameraFollowPlugins(viewport);
 
+  const position = readCameraFollowPosition(target);
+  if (!position) return false;
+
   const animationOptions = cameraFollowAnimationOptions(smoothMove);
   if (!animationOptions || animationOptions.time <= 0) {
-    followCameraInstantly(viewport, target, smoothMove);
-    return;
+    return followCameraInstantly(viewport, target, smoothMove);
   }
 
   viewport.animate({
-    position: { x: target.x, y: target.y },
+    position,
     time: animationOptions.time,
     ease: animationOptions.ease,
     callbackOnComplete: () => {
       if (!isCurrentRevision(followRevision) || !shouldFollowCamera()) return;
+      if (!readCameraFollowPosition(target)) return;
       followCameraInstantly(viewport, target, smoothMove);
     },
   });
+  return true;
 };

--- a/packages/server/src/Player/Player.ts
+++ b/packages/server/src/Player/Player.ts
@@ -80,6 +80,39 @@ const BasicPlayerMixins = combinePlayerMixins([
   WithBattleManager,
 ]);
 
+type CameraFollowEase =
+  | "linear"
+  | "easeInQuad"
+  | "easeOutQuad"
+  | "easeInOutQuad"
+  | "easeInCubic"
+  | "easeOutCubic"
+  | "easeInOutCubic"
+  | "easeInQuart"
+  | "easeOutQuart"
+  | "easeInOutQuart"
+  | "easeInQuint"
+  | "easeOutQuint"
+  | "easeInOutQuint"
+  | "easeInSine"
+  | "easeOutSine"
+  | "easeInOutSine"
+  | "easeInExpo"
+  | "easeOutExpo"
+  | "easeInOutExpo"
+  | "easeInCirc"
+  | "easeOutCirc"
+  | "easeInOutCirc"
+  | "easeInElastic"
+  | "easeOutElastic"
+  | "easeInOutElastic"
+  | "easeInBack"
+  | "easeOutBack"
+  | "easeInOutBack"
+  | "easeInBounce"
+  | "easeOutBounce"
+  | "easeInOutBounce";
+
 /**
  * RPG Player class with component management capabilities
  * 
@@ -1597,6 +1630,9 @@ export class RpgPlayer extends BasicPlayerMixins(RpgCommonPlayer) {
    * @param options.smoothMove - Enable smooth animation. Can be a boolean (default: true) or an object with animation parameters
    * @param options.smoothMove.time - Time duration for the animation in milliseconds (optional)
    * @param options.smoothMove.ease - Easing function name. Visit https://easings.net for available functions (optional)
+   * @param options.smoothMove.speed - Continuous follow speed after the transition (optional)
+   * @param options.smoothMove.acceleration - Continuous follow acceleration after the transition (optional)
+   * @param options.smoothMove.radius - Center radius where the target can move without moving the viewport (optional)
    * 
    * @example
    * ```ts
@@ -1618,7 +1654,14 @@ export class RpgPlayer extends BasicPlayerMixins(RpgCommonPlayer) {
   cameraFollow(
     otherPlayer: RpgPlayer | RpgEvent,
     options?: {
-      smoothMove?: boolean | { time?: number; ease?: string };
+      smoothMove?: boolean | {
+        enabled?: boolean;
+        time?: number;
+        ease?: CameraFollowEase;
+        speed?: number;
+        acceleration?: number | null;
+        radius?: number | null;
+      };
     }
   ): void {
     const map = this.getCurrentMap();

--- a/samples/sample-dev/src/components/map.ce
+++ b/samples/sample-dev/src/components/map.ce
@@ -1,5 +1,5 @@
 <Container>
-    <Rect width={500} height={500} color={color} />
+    <Rect width={5000} height={5000} color={color} />
     <EventLayerComponent></EventLayerComponent>
 </Container>
 

--- a/samples/sample-dev/src/config/config.client.ts
+++ b/samples/sample-dev/src/config/config.client.ts
@@ -49,8 +49,8 @@ export default {
        return {
           id,
           component: Map,
-          width: 500,
-          height: 500,
+          width: 5000,
+          height: 5000,
           data: {
             color: colorMap[id]
           },

--- a/samples/sample-dev/src/server.ts
+++ b/samples/sample-dev/src/server.ts
@@ -542,8 +542,8 @@ export default createServer({
             }
             
             player.changeMap("center-map", {
-              x: 100,
-              y: 100,
+              x: 500,
+              y: 500,
             });
 
             player.allRecovery()
@@ -609,6 +609,13 @@ export default createServer({
           async onInput(player: RpgPlayer, input: any) {
             // console.log("call shop")
 
+            if (input.action == 'action') {
+              const map = player.getCurrentMap()
+              const event = map?.getEvents()[0]
+              player?.cameraFollow(event, {
+                smoothMove: true
+              })
+            }
 
             // const choice = await player.showChoices('Hello', [
             //   { text: 'Fight', value: 'fight' },


### PR DESCRIPTION
## Summary
- guard camera follow setup when a map switch leaves the followed sprite target unreadable or destroyed
- wrap viewport follow targets so `x`/`y` reads fall back to the last known position after teardown
- clear camera follow plugins on character unmount when this component previously installed follow
- add regression tests and a patch changeset for `@rpgjs/client`

Fixes #314.

## Validation
- `pnpm vitest packages/client/src/services/cameraFollow.spec.ts`
- `pnpm --dir packages/client build`
