### PR TITLE
fix: initialize recursively nested providers

### DIFF
--- a/.changeset/fix-recursive-providers.md
+++ b/.changeset/fix-recursive-providers.md
@@ -1,0 +1,7 @@
+---
+"@rpgjs/client": patch
+"@rpgjs/server": patch
+---
+
+Initialize recursively nested RPGJS provider lists in client and server setup so
+sample and consumer configurations register every provider at runtime.

--- a/packages/client/src/core/setup.spec.ts
+++ b/packages/client/src/core/setup.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "vitest";
+import { RpgClientEngine } from "../RpgClientEngine";
+import { inject } from "./inject";
+import { startGame } from "./setup";
+
+describe("startGame", () => {
+  test("initializes recursively nested RPGJS providers", async () => {
+    let engineStarted = false;
+
+    const context = await startGame({
+      providers: [
+        [
+          [
+            {
+              provide: "deep-provider",
+              useValue: 42,
+            },
+          ],
+        ],
+        {
+          provide: RpgClientEngine,
+          useValue: {
+            async start() {
+              engineStarted = true;
+            },
+          },
+        },
+      ],
+    });
+
+    expect(context.side).toBe("client");
+    expect(inject("deep-provider")).toBe(42);
+    expect(engineStarted).toBe(true);
+  });
+});

--- a/packages/client/src/core/setup.ts
+++ b/packages/client/src/core/setup.ts
@@ -13,7 +13,8 @@ export async function startGame(options: SetupOptions): Promise<RpgContext> {
   context['side'] = 'client'
   setInject(context as unknown as RpgContext);
 
-  await injector(context, options.providers as Providers);
+  const providers = (options.providers as unknown[]).flat(Infinity) as Providers;
+  await injector(context, providers);
 
   const engine = inject<RpgClientEngine>(context, RpgClientEngine);
   await engine.start();

--- a/packages/server/src/core/setup.spec.ts
+++ b/packages/server/src/core/setup.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "vitest";
+import { createServer } from "./setup";
+
+describe("createServer", () => {
+  test("initializes recursively nested RPGJS providers", async () => {
+    const sentinel = new Error("deep provider initialized");
+    const Server = createServer({
+      providers: [
+        [
+          [
+            {
+              provide: "deep-provider",
+              useFactory() {
+                throw sentinel;
+              },
+            },
+          ],
+        ],
+      ],
+    });
+    const server = new Server({
+      id: "lobby-1",
+      storage: {},
+    } as never);
+
+    await expect(server.onStart()).rejects.toBe(sentinel);
+  });
+});

--- a/packages/server/src/core/setup.ts
+++ b/packages/server/src/core/setup.ts
@@ -14,7 +14,10 @@ export function createServer(options: SetupOptions): any {
     
     async onStart() {
       setInject(context);
-      await injector(context as any, options.providers as Providers);
+      const providers = (options.providers as unknown[]).flat(
+        Infinity,
+      ) as Providers;
+      await injector(context as any, providers);
       return super.onStart();
     }
   };


### PR DESCRIPTION
## What changed

- fully flatten RPGJS provider lists before client and server initialization
- add client and server regression tests for recursively nested providers
- add a patch changeset for `@rpgjs/client` and `@rpgjs/server`

## Root cause

`RpgProviders` intentionally accepts recursively nested provider lists, but the
underlying Signe injector only flattens one level. In `samples/sample-dev`,
`provideLoadMap()` therefore remained nested and `LoadMapToken` was never
registered, leaving the game blank at startup.

## Validation

- targeted client, server, and provider tests: 8 passed
- public API type contracts: 18 passed
- client and server package builds
- public boundary check with Bun
- `pnpm --filter sample build`: 1,122 modules built
- browser smoke test on `http://localhost:5173/`: title screen rendered,
  Start loaded the map, keyboard movement worked, WebSocket ping/pong succeeded,
  and no application page error or failed request was observed
