### PR TITLE
fix: scope Studio player config to joined map

### DIFF
--- a/.changeset/fresh-studio-map-config.md
+++ b/.changeset/fresh-studio-map-config.md
@@ -1,0 +1,6 @@
+---
+"@rpgjs/studio": patch
+---
+
+Scope Studio player initialization and starting database records to the joined
+map project so multi-project Workers do not leak global project configuration.

--- a/packages/studio/src/server.ts
+++ b/packages/studio/src/server.ts
@@ -93,8 +93,32 @@ export const resolveRuntimeEventHitbox = (object: any, params: any): { width: nu
   return normalizeRuntimeHitbox(object?.hitbox) ?? normalizeRuntimeHitbox(triggerHitbox) ?? normalizeRuntimeHitbox(params?.hitbox);
 };
 
-const resolvePlayerConfig = async (player: RpgPlayer): Promise<ProjectBasic> => {
-  const gameConfig = readGameConfig();
+const normalizeProjectId = (value: unknown): string | null => {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+};
+
+const resolveStudioRuntimeContext = (map?: RpgMap): { gameConfig: any; projectId: string | null } => {
+  const legacyGameConfig = readGameConfig();
+  const mapConfig = map?.globalConfig;
+  if (mapConfig && typeof mapConfig === "object" && Object.keys(mapConfig).length > 0) {
+    return {
+      gameConfig: mapConfig,
+      projectId:
+        normalizeProjectId(mapConfig._id ?? mapConfig.projectId)
+        ?? normalizeProjectId(getStudioGameRuntimeConfig().projectId)
+        ?? normalizeProjectId(legacyGameConfig?._id ?? legacyGameConfig?.projectId),
+    };
+  }
+  return {
+    gameConfig: legacyGameConfig,
+    projectId:
+      normalizeProjectId(getStudioGameRuntimeConfig().projectId)
+      ?? normalizeProjectId(legacyGameConfig?._id ?? legacyGameConfig?.projectId),
+  };
+};
+
+const resolvePlayerConfig = async (player: RpgPlayer, map?: RpgMap): Promise<ProjectBasic> => {
+  const { gameConfig, projectId } = resolveStudioRuntimeContext(map);
   const baseHeroConfig = {
     ...(gameConfig.hero ?? {}),
     skillsToLearn: gameConfig.skillsToLearn ?? gameConfig.skills ?? gameConfig.hero?.skillsToLearn ?? gameConfig.hero?.skills,
@@ -108,12 +132,11 @@ const resolvePlayerConfig = async (player: RpgPlayer): Promise<ProjectBasic> => 
   }
 
   try {
-    const configuredProjectId = getStudioGameRuntimeConfig().projectId?.trim() || null;
     const overrideConfig = await providerStartConfig.call(provider, {
       player,
       heroConfig: baseHeroConfig,
       gameConfig,
-      projectId: configuredProjectId || gameConfig?._id || null,
+      projectId,
       mapId: gameConfig?.startMapId || null,
     });
 
@@ -125,7 +148,7 @@ const resolvePlayerConfig = async (player: RpgPlayer): Promise<ProjectBasic> => 
 };
 
 const startGame = async (player: RpgPlayer, map?: RpgMap) => {
-  const heroConfig = await resolvePlayerConfig(player);
+  const heroConfig = await resolvePlayerConfig(player, map);
   (player as any).studioCombatAnimations = heroConfig.animations ?? {};
   (player as any).combatAnimations = heroConfig.animations ?? {};
   const startingItems = await ensureStartingItemsInDatabase(player, heroConfig, map);
@@ -237,9 +260,7 @@ const ensureStartingItemsInDatabase = async (player: RpgPlayer, config: ProjectB
   }, {});
   if (missingIds.length === 0) return startingItems;
 
-  const gameConfig = readGameConfig();
-  const configuredProjectId = getStudioGameRuntimeConfig().projectId?.trim() || null;
-  const projectId = configuredProjectId || gameConfig?._id || null;
+  const { projectId } = resolveStudioRuntimeContext(map);
 
   try {
     const records = await getGameDataProvider().getDatabase(projectId ?? undefined);

--- a/packages/studio/tests/studio-server-runtime.spec.ts
+++ b/packages/studio/tests/studio-server-runtime.spec.ts
@@ -1,5 +1,18 @@
-import { describe, expect, test } from "vitest";
-import { resolveRuntimeEventHitbox } from "../src/server";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { MAXHP, MAXSP } from "@rpgjs/common";
+import { RpgPlayer, type RpgMap } from "@rpgjs/server";
+import studioServer, { resolveRuntimeEventHitbox } from "../src/server";
+import {
+  configureGameDataProvider,
+  configureStudioGameRuntime,
+  resetGameDataProvider,
+} from "../src/data-provider";
+
+afterEach(() => {
+  delete (globalThis as typeof globalThis & { gameConfig?: unknown }).gameConfig;
+  configureStudioGameRuntime({ projectId: null });
+  resetGameDataProvider();
+});
 
 describe("Studio server runtime", () => {
   test("resolves the runtime event hitbox from the game map payload", () => {
@@ -34,5 +47,164 @@ describe("Studio server runtime", () => {
       width: 24,
       height: 40,
     });
+  });
+
+  test("initializes each player from the joined map project", async () => {
+    (globalThis as typeof globalThis & { gameConfig?: unknown }).gameConfig = {
+      _id: "global-project",
+      startMapId: "global-map",
+      hero: {
+        parameters: {
+          [MAXHP]: 1,
+          [MAXSP]: 1,
+          projectMarker: 1,
+        },
+      },
+    };
+    configureStudioGameRuntime({ projectId: "fixed-project" });
+
+    const getPlayerStartConfig = vi.fn(async ({ projectId }: { projectId?: string | null }) => ({
+      startingInventory: [{ itemId: `${projectId}-potion`, amount: 1 }],
+    }));
+    const getDatabase = vi.fn(async (projectId?: string) => ([{
+      _id: `${projectId}-potion`,
+      itemType: "item",
+      name: `${projectId} potion`,
+    }]));
+    configureGameDataProvider({
+      kind: "online",
+      getProject: vi.fn(),
+      getMap: vi.fn(),
+      getMedia: vi.fn(),
+      getPlayerStartConfig,
+      getDatabase,
+    });
+
+    const onJoinMap = (studioServer() as any).player.onJoinMap as (player: RpgPlayer, map: RpgMap) => Promise<void>;
+    const projects = [
+      { id: "project-a", mapId: "map-a", maxHp: 90, maxSp: 45, marker: 101 },
+      { id: "project-b", mapId: "map-b", maxHp: 80, maxSp: 40, marker: 202 },
+    ];
+
+    for (const project of projects) {
+      const database: Record<string, any> = {};
+      const map = {
+        globalConfig: {
+          _id: project.id,
+          startMapId: project.mapId,
+          hero: {
+            parameters: {
+              [MAXHP]: project.maxHp,
+              [MAXSP]: project.maxSp,
+              projectMarker: project.marker,
+            },
+          },
+        },
+        database: () => database,
+        addInDatabase: (id: string, value: any) => {
+          database[id] = value;
+        },
+        startPosition: { x: 0, y: 0 },
+        scale: 1,
+      } as unknown as RpgMap;
+      const player = new RpgPlayer();
+      player.initializeDefaultStats();
+      player.setMap(map);
+
+      await onJoinMap(player, map);
+
+      expect(player.param[MAXHP]).toBe(project.maxHp);
+      expect(player.param[MAXSP]).toBe(project.maxSp);
+      expect(player.hp).toBe(project.maxHp);
+      expect(player.sp).toBe(project.maxSp);
+      expect(player.param.projectMarker).toBe(project.marker);
+      expect(database[`${project.id}-potion`]?.name).toBe(`${project.id} potion`);
+    }
+
+    expect(getPlayerStartConfig.mock.calls.map(([query]) => ({
+      projectId: query.projectId,
+      mapId: query.mapId,
+    }))).toEqual([
+      { projectId: "project-a", mapId: "map-a" },
+      { projectId: "project-b", mapId: "map-b" },
+    ]);
+    expect(getDatabase.mock.calls.map(([projectId]) => projectId)).toEqual([
+      "project-a",
+      "project-b",
+    ]);
+  });
+
+  test("keeps the legacy global project fallback for maps without config", async () => {
+    (globalThis as typeof globalThis & { gameConfig?: unknown }).gameConfig = {
+      _id: "legacy-project",
+      startMapId: "legacy-map",
+      hero: {
+        parameters: {
+          projectMarker: 303,
+        },
+      },
+    };
+    const getPlayerStartConfig = vi.fn(async () => null);
+    configureGameDataProvider({
+      kind: "online",
+      getProject: vi.fn(),
+      getMap: vi.fn(),
+      getMedia: vi.fn(),
+      getDatabase: vi.fn(async () => []),
+      getPlayerStartConfig,
+    });
+
+    const player = new RpgPlayer();
+    const map = {
+      globalConfig: {},
+      database: () => ({}),
+      addInDatabase: vi.fn(),
+      startPosition: { x: 0, y: 0 },
+      scale: 1,
+    } as unknown as RpgMap;
+    player.setMap(map);
+
+    await (studioServer() as any).player.onJoinMap(player, map);
+
+    expect(player.param.projectMarker).toBe(303);
+    expect(getPlayerStartConfig).toHaveBeenCalledWith(expect.objectContaining({
+      projectId: "legacy-project",
+      mapId: "legacy-map",
+    }));
+  });
+
+  test("prefers a configured fixed project before the legacy project id", async () => {
+    (globalThis as typeof globalThis & { gameConfig?: unknown }).gameConfig = {
+      _id: "legacy-project",
+      startMapId: "legacy-map",
+      hero: {},
+    };
+    configureStudioGameRuntime({ projectId: "fixed-project" });
+    const getPlayerStartConfig = vi.fn(async () => null);
+    configureGameDataProvider({
+      kind: "online",
+      getProject: vi.fn(),
+      getMap: vi.fn(),
+      getMedia: vi.fn(),
+      getDatabase: vi.fn(async () => []),
+      getPlayerStartConfig,
+    });
+
+    const player = new RpgPlayer();
+    const map = {
+      globalConfig: {},
+      database: () => ({}),
+      addInDatabase: vi.fn(),
+      startPosition: { x: 0, y: 0 },
+      scale: 1,
+    } as unknown as RpgMap;
+    player.setMap(map);
+
+    await (studioServer() as any).player.onJoinMap(player, map);
+
+    expect(getPlayerStartConfig).toHaveBeenCalledWith(expect.objectContaining({
+      projectId: "fixed-project",
+      mapId: "legacy-map",
+    }));
   });
 });


### PR DESCRIPTION
## What changed

- resolve Studio player hero configuration from the joined map's `globalConfig`
- use the same map-scoped project ID for `getPlayerStartConfig()` and starting database preload
- preserve the fallback order: joined map, configured fixed project, then legacy global configuration
- add regression coverage for two projects in one Worker isolate, coherent HP/SP, project-scoped starting records, and legacy/fixed-project fallbacks
- add a patch changeset for `@rpgjs/studio`

## Root cause

Player initialization and starting-item preload read process-global Studio configuration. In a multi-project Durable Object Worker, that configuration did not represent the map the player had joined, allowing missing values or cross-project data leakage.

## Validation

- `pnpm vitest run packages/studio` — 27 files, 180 tests passed
- `pnpm vitest run packages/studio/tests/studio-server-runtime.spec.ts` — 6 tests passed after final resolver changes
- `pnpm --filter @rpgjs/studio build` — passed
- `rpgjs/starter` `v5` smoke test with the packed local `@rpgjs/studio` artifact — production build passed; development game rendered in Chromium; keyboard movement exercised; no application console errors or failed requests
- starter-only warning: missing `favicon.ico` returns 404

Closes #322
