### PR TITLE
fix: allow trusted Studio data providers

### DIFF
--- a/.changeset/trusted-studio-provider.md
+++ b/.changeset/trusted-studio-provider.md
@@ -1,0 +1,6 @@
+---
+"@rpgjs/studio": patch
+---
+
+Allow trusted Studio map publishers to inject a server-owned data provider for
+project, map, media, and database reads without calling the public Studio API.

--- a/docs/internal/signe-public-boundary.snapshot.json
+++ b/docs/internal/signe-public-boundary.snapshot.json
@@ -2591,6 +2591,7 @@
     "exports": [
       "CreateStudioMapPluginsOptions",
       "CreateStudioMapUpdatePayloadOptions",
+      "GameDataProvider",
       "StudioCombatAnimationIds",
       "StudioCombatAnimationOptions",
       "StudioDebugCollisionsOptions",

--- a/docs/studio/game-integration.md
+++ b/docs/studio/game-integration.md
@@ -174,6 +174,39 @@ the room. This direct `curl` updates only one map revision; it does not perform
 the world fan-out. Use the RPGJS publisher or the Studio seed command for a full
 map-and-world publication.
 
+### Trusted publisher data provider
+
+A trusted backend that already owns the Studio project data can inject a
+`GameDataProvider` and avoid calling the public Studio API while preparing an
+MMORPG map update:
+
+```ts
+import {
+  createStudioMapUpdatePayload,
+  type GameDataProvider,
+} from "@rpgjs/studio/server";
+
+const databaseBackedStudioProvider: GameDataProvider = {
+  kind: "online",
+  getProject: async ({ projectId, mapId }) => loadProject({ projectId, mapId }),
+  getMap: async (mapId) => loadMap(mapId),
+  getMedia: async (mediaId) => loadMedia(mediaId),
+  getDatabase: async (projectId) => loadDatabase(projectId),
+};
+
+await createStudioMapUpdatePayload("your-map-id", {
+  projectId: "your-project-id",
+  startMapId: "your-map-id",
+  dataProvider: databaseBackedStudioProvider,
+});
+```
+
+The injected provider handles every project, map, event-media, and database
+read for that payload. It is server-owned in both standalone and MMORPG
+deployments: never expose database adapters, private storage handles, or
+credentials to browser code. When `dataProvider` is omitted, the existing
+online, offline, and auto runtime modes keep selecting the built-in provider.
+
 For a runnable local Worker, deterministic fixture, seed script, and real Studio
 API seed command, see the
 [Studio playground](https://github.com/RSamaium/RPG-JS/tree/master/playground/games/studio).

--- a/packages/studio/src/server-entry.ts
+++ b/packages/studio/src/server-entry.ts
@@ -1,3 +1,4 @@
 export * from "./index";
 export { createStudioMapUpdatePayload } from "./server";
 export type { CreateStudioMapUpdatePayloadOptions } from "./server";
+export type { GameDataProvider } from "./data-provider";

--- a/packages/studio/src/server.ts
+++ b/packages/studio/src/server.ts
@@ -9,7 +9,7 @@ import { applyTriggerSettings, getEventTypeRuntime, getGraphicKey, getGraphicSca
 import { normalizeEventType } from "@common/event-types";
 import { normalizeWeatherState } from "@common/weather";
 import { getGameDataProvider, getStudioGameRuntimeConfig, configureStudioGameRuntime, resetGameDataProvider } from "./data-provider";
-import type { GameRuntimeMode } from "./data-provider";
+import type { GameDataProvider, GameRuntimeMode } from "./data-provider";
 import { normalizeStudioDatabase, normalizeStudioDatabaseRecord } from "./database-normalizer";
 import { createStudioDefaultClass } from "./skills-to-learn";
 import { getStudioSkillChangeNotification } from "./skill-notification";
@@ -290,6 +290,12 @@ export interface CreateStudioMapUpdatePayloadOptions {
   projectId?: string | null;
   /** Map used when the project does not define another starting map. */
   startMapId?: string;
+  /**
+   * Trusted server-owned Studio data source used for project, map, media, and
+   * database reads. Browser code must not receive providers that expose private
+   * storage or credentials.
+   */
+  dataProvider?: GameDataProvider;
   /** Studio data source. Trusted publishers normally use `online`. */
   runtimeMode?: GameRuntimeMode;
   /** Compatibility alias for `apiUrl`. */
@@ -374,7 +380,7 @@ const toIdentifierString = (value: unknown): string => {
   return toIdentifierString(record._id) || toIdentifierString(record.id) || toIdentifierString(record.mediaId) || toIdentifierString(record.referenceId);
 };
 
-const resolveMediaReference = async (value: unknown): Promise<unknown> => {
+const resolveMediaReference = async (value: unknown, provider: GameDataProvider): Promise<unknown> => {
   if (!value) return value;
   const referenceId = toIdentifierString(value);
   if (!referenceId) return value;
@@ -383,7 +389,7 @@ const resolveMediaReference = async (value: unknown): Promise<unknown> => {
 
   for (const candidateId of candidateIds) {
     try {
-      const media = await getGameDataProvider().getMedia(candidateId);
+      const media = await provider.getMedia(candidateId);
       if (media && !media.__placeholder) {
         return value && typeof value === "object" ? { ...(value as Record<string, unknown>), ...media } : media;
       }
@@ -395,7 +401,10 @@ const resolveMediaReference = async (value: unknown): Promise<unknown> => {
   return value;
 };
 
-const hydrateEventMediaReferences = async (events: any[]): Promise<any[]> => {
+const hydrateEventMediaReferences = async (
+  events: any[],
+  provider: GameDataProvider = getGameDataProvider(),
+): Promise<any[]> => {
   return Promise.all(
     events.map(async (event) => {
       if (!event || typeof event !== "object") return event;
@@ -403,7 +412,7 @@ const hydrateEventMediaReferences = async (events: any[]): Promise<any[]> => {
       if (nextEvent.params?.graphic) {
         nextEvent.params = {
           ...nextEvent.params,
-          graphic: await resolveMediaReference(nextEvent.params.graphic),
+          graphic: await resolveMediaReference(nextEvent.params.graphic, provider),
         };
       }
       if (Array.isArray(nextEvent.triggers)) {
@@ -413,7 +422,7 @@ const hydrateEventMediaReferences = async (events: any[]): Promise<any[]> => {
             if (!trigger.graphic) return trigger;
             return {
               ...trigger,
-              graphic: await resolveMediaReference(trigger.graphic),
+              graphic: await resolveMediaReference(trigger.graphic, provider),
             };
           }),
         );
@@ -497,15 +506,28 @@ const parseJsonValue = (value: unknown, fallback: any): any => {
   }
 };
 
-const resolveStudioProject = async (mapId?: string, config: StudioServerConfig = {}): Promise<any> => {
+const resolveStudioProject = async (
+  mapId?: string,
+  config: StudioServerConfig = {},
+  provider: GameDataProvider = config.dataProvider ?? getGameDataProvider(),
+): Promise<any> => {
   const runtimeConfig = getStudioGameRuntimeConfig();
   const gameConfig = readGameConfig();
   const projectId = config.projectId?.trim?.() || runtimeConfig.projectId?.trim?.() || gameConfig?._id || null;
+  const query = projectId ? { projectId } : { mapId };
+
+  if (config.dataProvider) {
+    return provider.getProject(query).catch((error) => {
+      console.warn("[StudioGame] project preload failed", error);
+      return {};
+    });
+  }
+
   const cacheKey = projectId ? `project:${projectId}` : `map:${mapId ?? ""}`;
 
   if (!projectCacheByKey.has(cacheKey)) {
-    const promise = getGameDataProvider()
-      .getProject(projectId ? { projectId } : { mapId })
+    const promise = provider
+      .getProject(query)
       .catch((error) => {
         projectCacheByKey.delete(cacheKey);
         console.warn("[StudioGame] project preload failed", error);
@@ -527,16 +549,28 @@ const resolveStartMapId = async (config: StudioServerConfig): Promise<string> =>
   return project?.startMapId || "simplemap";
 };
 
-const normalizeStudioMapPayload = async (mapId: string, initialMapData: any, config: StudioServerConfig): Promise<any> => {
+const normalizeStudioMapPayload = async (
+  mapId: string,
+  initialMapData: any,
+  config: StudioServerConfig,
+  provider?: GameDataProvider,
+): Promise<any> => {
   if (initialMapData?.data?.params) return initialMapData;
+  const resolvedProvider = provider ?? config.dataProvider ?? getGameDataProvider();
 
-  const [project, mapResponse] = await Promise.all([resolveStudioProject(mapId, config), getGameDataProvider().getMap(mapId)]);
+  const [project, mapResponse] = await Promise.all([
+    resolveStudioProject(mapId, config, resolvedProvider),
+    resolvedProvider.getMap(mapId),
+  ]);
   const useLocalBundleEvents = shouldUseLocalBundleEvents(config);
   const params = mapResponse.params ?? {};
   const isV2 = mapResponse.creationDetails?.version === "v2";
   const resolvedEvents = await resolveMapEventReferences(mapResponse.events ?? mapResponse.data?.events, { useLocalBundleEvents });
-  const hydratedEvents = await hydrateEventMediaReferences(resolvedEvents);
-  const hydratedCommonEvents = await hydrateEventMediaReferences(parseArrayValue(mapResponse.commonEvents ?? mapResponse.data?.commonEvents));
+  const hydratedEvents = await hydrateEventMediaReferences(resolvedEvents, resolvedProvider);
+  const hydratedCommonEvents = await hydrateEventMediaReferences(
+    parseArrayValue(mapResponse.commonEvents ?? mapResponse.data?.commonEvents),
+    resolvedProvider,
+  );
   const mapDataValue = Array.isArray(mapResponse.data) ? mapResponse.data : parseJsonValue(mapResponse.data, []);
   const mergedHitboxes = [...(mapResponse.hitboxes ?? [])];
 
@@ -602,6 +636,7 @@ export async function createStudioMapUpdatePayload(mapId: string, config: Create
     bundleBasePath: config.bundleBasePath,
   });
   resetGameDataProvider();
+  const provider = config.dataProvider ?? getGameDataProvider();
   const normalized = await normalizeStudioMapPayload(
     mapId,
     {
@@ -611,9 +646,10 @@ export async function createStudioMapUpdatePayload(mapId: string, config: Create
       events: [],
     },
     config,
+    provider,
   );
   const projectId = config.projectId?.trim() || normalized.config?._id || normalized.data?.projectId;
-  const database = projectId ? await getGameDataProvider().getDatabase(projectId) : [];
+  const database = projectId ? await provider.getDatabase(projectId) : [];
   const preparedMap = prepareStudioMapPayload(normalized, {
     id: mapId,
     config: normalized.config,

--- a/packages/studio/tests/studio-server-runtime.spec.ts
+++ b/packages/studio/tests/studio-server-runtime.spec.ts
@@ -1,12 +1,16 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { MAXHP, MAXSP } from "@rpgjs/common";
 import { RpgPlayer, type RpgMap } from "@rpgjs/server";
-import studioServer, { resolveRuntimeEventHitbox } from "../src/server";
+import studioServer, {
+  createStudioMapUpdatePayload,
+  resolveRuntimeEventHitbox,
+} from "../src/server";
 import {
   configureGameDataProvider,
   configureStudioGameRuntime,
   resetGameDataProvider,
 } from "../src/data-provider";
+import type { GameDataProvider } from "../src/server-entry";
 
 afterEach(() => {
   delete (globalThis as typeof globalThis & { gameConfig?: unknown }).gameConfig;
@@ -15,6 +19,66 @@ afterEach(() => {
 });
 
 describe("Studio server runtime", () => {
+  test("uses an injected provider to prepare trusted map updates", async () => {
+    const getProject = vi.fn(async () => ({
+      _id: "trusted-project",
+      startMapId: "trusted-map",
+    }));
+    const getMap = vi.fn(async () => ({
+      _id: "trusted-map",
+      projectId: "trusted-project",
+      creationDetails: { version: "v2" },
+      params: { width: 2, height: 3 },
+      events: [{
+        id: "event-1",
+        params: { graphic: { _id: "#hero-media" } },
+      }],
+      commonEvents: [{
+        id: "common-event-1",
+        triggers: [{ graphic: { mediaId: "trigger-media" } }],
+      }],
+      terrain: [],
+      terrainByTileset: [],
+    }));
+    const getMedia = vi.fn(async (mediaId: string) => ({
+      _id: mediaId,
+      url: `https://private.example/${mediaId}.png`,
+    }));
+    const getDatabase = vi.fn(async () => [{
+      _id: "potion",
+      itemType: "item",
+      name: "Trusted potion",
+    }]);
+    const dataProvider: GameDataProvider = {
+      kind: "online",
+      getProject,
+      getMap,
+      getMedia,
+      getDatabase,
+    };
+
+    const payload = await createStudioMapUpdatePayload("trusted-map", {
+      projectId: "trusted-project",
+      dataProvider,
+    });
+
+    expect(getProject).toHaveBeenCalledWith({ projectId: "trusted-project" });
+    expect(getMap).toHaveBeenCalledWith("trusted-map");
+    expect(getMedia.mock.calls.map(([mediaId]) => mediaId)).toEqual([
+      "hero-media",
+      "trigger-media",
+    ]);
+    expect(getDatabase).toHaveBeenCalledWith("trusted-project");
+    expect(payload.database).toEqual([expect.objectContaining({
+      _id: "potion",
+      name: "Trusted potion",
+    })]);
+    expect(payload.events[0].params.graphic).toEqual(expect.objectContaining({
+      _id: "hero-media",
+      url: "https://private.example/hero-media.png",
+    }));
+  });
+
   test("resolves the runtime event hitbox from the game map payload", () => {
     expect(resolveRuntimeEventHitbox({
       hitbox: { width: 56, height: 50 },


### PR DESCRIPTION
## Summary

- add `dataProvider?: GameDataProvider` to `CreateStudioMapUpdatePayloadOptions`
- route project, map, event/common-event media, and database reads through the injected trusted provider
- export `GameDataProvider` from `@rpgjs/studio/server`
- document trusted server ownership and preserve the built-in online/offline/auto behavior when omitted
- add a patch changeset for `@rpgjs/studio`

## Root cause

`createStudioMapUpdatePayload()` always resolved the global provider after
configuring online mode. Trusted publishers that already owned Studio project
data therefore had to call the public Studio API, causing the Studio Cloudflare
Worker to make failing self-subrequests.

The injected provider is now passed explicitly through payload preparation and
is not installed into global runtime state.

## Validation

- `pnpm vitest run packages/studio/tests` — 19 files, 92 tests passed
- `pnpm test:types` — 3 files, 18 tests passed, no type errors
- `pnpm api:boundary` — 24 public entry points checked
- `pnpm --dir packages/studio build`
- `pnpm build`
- packed local `@rpgjs/studio` and installed it into `rpgjs/starter` branch `v5-studio`; production build and fixed-port startup succeeded
- reviewed the starter screenshot; the missing `/game-data` offline-bundle warnings also occur with the currently published `@rpgjs/studio@5.0.0-beta.27`

Fixes #326
