### PR TITLE
fix: preserve Studio database in map updates

### DIFF
--- a/.changeset/rare-maps-keep-database.md
+++ b/.changeset/rare-maps-keep-database.md
@@ -1,0 +1,7 @@
+---
+"@rpgjs/server": patch
+---
+
+Preserve trusted Studio databases through map update validation and durable room
+restoration so player inventory and equipment initialization do not require an
+HTTP database fallback.

--- a/packages/server/src/rooms/map.ts
+++ b/packages/server/src/rooms/map.ts
@@ -194,6 +194,17 @@ const MapUpdateSchema = z.object({
   parsedMap: z.any().optional(),
   /** Raw map source payload (optional) */
   data: z.any().optional(),
+  /**
+   * Server-owned game database published with the map (optional).
+   *
+   * Studio publishes either its record array or an already normalized record.
+   * Keeping it in the validated payload lets database hooks populate the room
+   * without an HTTP fallback and preserves it across room restoration.
+   */
+  database: z.union([
+    z.array(z.any()),
+    z.record(z.string(), z.any()),
+  ]).optional(),
   /** Optional map params payload */
   params: z.any().optional(),
 });
@@ -2084,7 +2095,14 @@ export class RpgMap extends RpgCommonMap<RpgPlayer> {
    * ```ts
    * // This endpoint is called automatically when a map is loaded
    * // POST /map/update
-   * // Body: { id: string, width: number, height: number, config?: any, damageFormulas?: any }
+   * // Body: {
+   * //   id: string,
+   * //   width: number,
+   * //   height: number,
+   * //   config?: any,
+   * //   damageFormulas?: any,
+   * //   database?: any[] | Record<string, any>
+   * // }
    * ```
    */
   @Request({

--- a/packages/server/tests/node-transport.spec.ts
+++ b/packages/server/tests/node-transport.spec.ts
@@ -4,7 +4,13 @@ import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { createServer, provideServerModules } from "../src";
 import { RpgServerEngine } from "../src/RpgServerEngine";
-import { MAP_UPDATE_TOKEN_ENV, PartyConnection, createMapUpdatePayload, createRpgServerTransport } from "../src/node";
+import {
+  MAP_UPDATE_TOKEN_ENV,
+  PartyConnection,
+  createMapUpdatePayload,
+  createMemoryNodeRoomStorage,
+  createRpgServerTransport,
+} from "../src/node";
 
 function wait(ms = 0): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -447,6 +453,99 @@ describe("createRpgServerTransport", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toContain("application/json");
+  });
+
+  it.each([
+    {
+      label: "array",
+      database: [
+        { _id: "potion", itemType: "item", name: "Published potion" },
+      ],
+      expected: {
+        potion: { id: "potion", name: "Published potion" },
+      },
+    },
+    {
+      label: "object",
+      database: {
+        sword: { id: "sword", name: "Published sword" },
+      },
+      expected: {
+        sword: { id: "sword", name: "Published sword" },
+      },
+    },
+  ])("preserves a published $label database through validation and restoration", async ({
+    database,
+    expected,
+  }) => {
+    const storage = createMemoryNodeRoomStorage();
+    const GameServer = createServer({
+      providers: [
+        provideServerModules([
+          {
+            database(map: any) {
+              const published = map.data()?.database;
+              if (!Array.isArray(published)) {
+                return published ?? {};
+              }
+              return Object.fromEntries(published.map((record) => [
+                record._id ?? record.id,
+                {
+                  id: record._id ?? record.id,
+                  name: record.name,
+                },
+              ]));
+            },
+          },
+        ]),
+      ],
+    });
+    const transport = createRpgServerTransport(GameServer as any, {
+      initializeMaps: false,
+      storage,
+    });
+
+    const response = await transport.updateMap("published-database", {
+      id: "published-database",
+      width: 320,
+      height: 240,
+      events: [],
+      database,
+    });
+
+    expect(response.status).toBe(200);
+    const room = transport.getRoom("map-published-database")!;
+    const map = (transport.getServer("map-published-database") as RealServer)
+      .getCurrentRoom<any>();
+    expect(await room.storage.get("$room:rpgjs-map-source")).toMatchObject({
+      database,
+    });
+    expect(map.database()).toEqual(expected);
+
+    map.database.set({});
+    map.data.set(await room.storage.get("$room:rpgjs-map-source"));
+    await map.onRestore();
+
+    expect(map.database()).toEqual(expected);
+  });
+
+  it("keeps map updates without a published database backward compatible", async () => {
+    const transport = createRpgServerTransport(RealServer as any, {
+      initializeMaps: false,
+    });
+
+    const response = await transport.updateMap("legacy-map", {
+      id: "legacy-map",
+      width: 320,
+      height: 240,
+      events: [],
+    });
+
+    expect(response.status).toBe(200);
+    const map = (transport.getServer("map-legacy-map") as RealServer)
+      .getCurrentRoom<any>();
+    expect(map.data()).not.toHaveProperty("database");
+    expect(map.database()).toEqual({});
   });
 
   it("authenticates and durably restores world updates", async () => {

--- a/packages/studio/tests/studio-server-runtime.spec.ts
+++ b/packages/studio/tests/studio-server-runtime.spec.ts
@@ -79,6 +79,109 @@ describe("Studio server runtime", () => {
     }));
   });
 
+  test.each([
+    {
+      label: "record arrays",
+      published: [
+        { _id: "potion", itemType: "item", name: "Published potion" },
+      ],
+      expected: {
+        potion: {
+          id: "potion",
+          _type: "item",
+          name: "Published potion",
+        },
+      },
+    },
+    {
+      label: "normalized objects",
+      published: {
+        potion: {
+          id: "potion",
+          _type: "item",
+          name: "Published potion",
+        },
+      },
+      expected: {
+        potion: {
+          id: "potion",
+          _type: "item",
+          name: "Published potion",
+        },
+      },
+    },
+  ])("loads published Studio database $label without an HTTP fallback", async ({
+    published,
+    expected,
+  }) => {
+    const getDatabase = vi.fn(async () => {
+      throw new Error("The published database should avoid the HTTP provider");
+    });
+    configureGameDataProvider({
+      kind: "online",
+      getProject: vi.fn(),
+      getMap: vi.fn(),
+      getMedia: vi.fn(),
+      getDatabase,
+    });
+    const loadDatabase = (studioServer() as any).database as (
+      map: Pick<RpgMap, "data">,
+    ) => Promise<Record<string, any>>;
+
+    await expect(loadDatabase({
+      data: () => ({ database: published }),
+    } as Pick<RpgMap, "data">)).resolves.toEqual(expected);
+    expect(getDatabase).not.toHaveBeenCalled();
+  });
+
+  test("initializes starting inventory and equipment from the published database", async () => {
+    const getDatabase = vi.fn(async () => {
+      throw new Error("Player initialization should use the published database");
+    });
+    configureGameDataProvider({
+      kind: "online",
+      getProject: vi.fn(),
+      getMap: vi.fn(),
+      getMedia: vi.fn(),
+      getDatabase,
+    });
+    const database = {
+      potion: {
+        id: "potion",
+        _type: "item",
+        name: "Published potion",
+      },
+      sword: {
+        id: "sword",
+        _type: "weapon",
+        name: "Published sword",
+      },
+    };
+    const map = {
+      globalConfig: {
+        startMapId: "published-map",
+        hero: {
+          startingInventory: [{ itemId: "potion", amount: 2 }],
+          startingEquipment: { weapon: "sword" },
+        },
+      },
+      database: () => database,
+      addInDatabase: vi.fn(),
+      startPosition: { x: 0, y: 0 },
+      scale: 1,
+    } as unknown as RpgMap;
+    const player = new RpgPlayer();
+    player.initializeDefaultStats();
+    player.setMap(map);
+
+    await (studioServer() as any).player.onJoinMap(player, map);
+
+    expect(player.getItem("potion")?.quantity()).toBe(2);
+    expect(player.getItem("sword")?.quantity()).toBe(1);
+    expect(player.equipments().some((item) => item.id() === "sword")).toBe(true);
+    expect(getDatabase).not.toHaveBeenCalled();
+  });
+
   test("resolves the runtime event hitbox from the game map payload", () => {
     expect(resolveRuntimeEventHitbox({
       hitbox: { width: 56, height: 50 },


### PR DESCRIPTION
## Résumé

- conserve `database` dans le payload validé de `POST /map/update` pour les formats tableau et objet
- persiste la source de carte complète et reconstruit `map.database()` après restauration du room
- évite le fallback HTTP lors de l’initialisation de l’inventaire et de l’équipement Studio
- ajoute le changeset patch pour `@rpgjs/server`

## Vérifications

- `pnpm exec vitest run` — 151 fichiers, 1103 tests réussis, 19 ignorés
- tests Cloudflare du sample MMORPG et du playground Studio
- builds `@rpgjs/server`, `@rpgjs/studio`, sample Cloudflare et playground Studio Cloudflare
- contrats TypeScript et frontière API publique

Fixes #329