### PR TITLE
feat: expose server step metrics

### DIFF
--- a/.changeset/calm-maps-report-steps.md
+++ b/.changeset/calm-maps-report-steps.md
@@ -1,0 +1,6 @@
+---
+"@rpgjs/server": patch
+---
+
+Call the documented server `onStep` hook after each queued map tick with typed
+duration, backlog, fixed-step, and pending-input metrics.

--- a/docs/hooks/server-engine-hooks.md
+++ b/docs/hooks/server-engine-hooks.md
@@ -16,8 +16,9 @@ const engine: RpgServerEngineHooks = {
     onStart(server: RpgServerEngine) {
         console.log('Server is starting...')
     },
-    onStep(server: RpgServerEngine) {
-        // Called at each server frame (60 FPS)
+    onStep(server: RpgServerEngine, metrics) {
+        // Called after each queued map tick
+        console.log(metrics.durationMs, metrics.pendingInputs)
     },
     auth(server: RpgServerEngine, socket: any) {
         // Custom authentication logic
@@ -59,19 +60,61 @@ const engine: RpgServerEngineHooks = {
 
 ### onStep
 
-**Description:** Called at each server frame, typically representing 60 FPS
+**Description:** Called after each queued map tick has been processed. Empty maps
+stop their automatic loop, so observability does not keep an idle room active.
 
 **Parameters:**
 - `server: RpgServerEngine` - The server engine instance
+- `metrics: RpgServerStepMetrics` - Metrics for the processed map tick:
+  - `tick` - Current fixed simulation tick
+  - `durationMs` - Wall-clock processing duration, excluding the hook itself
+  - `scheduledDeltaMs` - Delta passed to the queued tick
+  - `queuedDeltaMs` - Delta that arrived during processing and remains queued
+  - `fixedSteps` - Number of fixed simulation steps executed
+  - `pendingInputs` - Total unprocessed player inputs after the tick
+
+Handlers that only accept `server` remain compatible. Async handlers are awaited
+in the tick queue. If a handler throws or rejects, RPGJS logs the error for the
+automatic loop and retries queued simulation work on a later tick. Avoid network
+I/O here because it directly increases the server backlog.
 
 **Example:**
 ```ts
+import type { RpgServerEngineHooks, RpgServerStepMetrics } from '@rpgjs/server'
+
+const window = {
+    startedAt: Date.now(),
+    ticks: 0,
+    durationMs: 0,
+    maxQueuedDeltaMs: 0,
+    maxPendingInputs: 0
+}
+
 const engine: RpgServerEngineHooks = {
-    onStep(server: RpgServerEngine) {
-        // Update global timers, check conditions, etc.
-        const currentTime = Date.now()
-        if (currentTime % 10000 === 0) { // Every 10 seconds
-            console.log(`Server running for ${currentTime - server.globalData.startTime}ms`)
+    onStep(server, metrics: RpgServerStepMetrics) {
+        window.ticks += metrics.fixedSteps
+        window.durationMs += metrics.durationMs
+        window.maxQueuedDeltaMs = Math.max(
+            window.maxQueuedDeltaMs,
+            metrics.queuedDeltaMs
+        )
+        window.maxPendingInputs = Math.max(
+            window.maxPendingInputs,
+            metrics.pendingInputs
+        )
+
+        if (Date.now() - window.startedAt >= 10_000) {
+            // Enqueue this aggregate for an out-of-band exporter instead of
+            // performing analytics or network I/O on every server tick.
+            metricsQueue.push({
+                mapId: server.getCurrentRoomId(),
+                ...window
+            })
+            window.startedAt = Date.now()
+            window.ticks = 0
+            window.durationMs = 0
+            window.maxQueuedDeltaMs = 0
+            window.maxPendingInputs = 0
         }
     }
 }

--- a/docs/hooks/server-engine-hooks.md
+++ b/docs/hooks/server-engine-hooks.md
@@ -60,17 +60,20 @@ const engine: RpgServerEngineHooks = {
 
 ### onStep
 
-**Description:** Called after each queued map tick has been processed. Empty maps
-stop their automatic loop, so observability does not keep an idle room active.
+**Description:** Called for map rooms, once after each queued map tick has been
+processed. It is not emitted for lobby rooms. A queued tick is one pass through
+the server scheduler; depending on the accumulated delta, it can execute zero,
+one, or several fixed simulation steps. Empty maps stop their automatic loop, so
+observability does not keep an idle room active.
 
 **Parameters:**
 - `server: RpgServerEngine` - The server engine instance
 - `metrics: RpgServerStepMetrics` - Metrics for the processed map tick:
-  - `tick` - Current fixed simulation tick
-  - `durationMs` - Wall-clock processing duration, excluding the hook itself
-  - `scheduledDeltaMs` - Delta passed to the queued tick
-  - `queuedDeltaMs` - Delta that arrived during processing and remains queued
-  - `fixedSteps` - Number of fixed simulation steps executed
+  - `tick` - Current cumulative fixed simulation tick after processing
+  - `durationMs` - Wall-clock processing duration in milliseconds, excluding the hook itself
+  - `scheduledDeltaMs` - Delta in milliseconds passed to the queued tick
+  - `queuedDeltaMs` - Delta in milliseconds that arrived during processing and remains queued
+  - `fixedSteps` - Number of fixed simulation steps executed (which can be zero or greater)
   - `pendingInputs` - Total unprocessed player inputs after the tick
 
 Handlers that only accept `server` remain compatible. Async handlers are awaited
@@ -82,17 +85,31 @@ I/O here because it directly increases the server backlog.
 ```ts
 import type { RpgServerEngineHooks, RpgServerStepMetrics } from '@rpgjs/server'
 
-const window = {
-    startedAt: Date.now(),
-    ticks: 0,
-    durationMs: 0,
-    maxQueuedDeltaMs: 0,
-    maxPendingInputs: 0
+type MetricsWindow = {
+    startedAt: number
+    fixedSteps: number
+    durationMs: number
+    maxQueuedDeltaMs: number
+    maxPendingInputs: number
 }
+
+function createMetricsWindow(): MetricsWindow {
+    return {
+        startedAt: Date.now(),
+        fixedSteps: 0,
+        durationMs: 0,
+        maxQueuedDeltaMs: 0,
+        maxPendingInputs: 0
+    }
+}
+
+// Application-owned queue drained by an exporter outside the tick hook.
+const metricsQueue: Array<MetricsWindow & { mapId: string | null }> = []
+let window = createMetricsWindow()
 
 const engine: RpgServerEngineHooks = {
     onStep(server, metrics: RpgServerStepMetrics) {
-        window.ticks += metrics.fixedSteps
+        window.fixedSteps += metrics.fixedSteps
         window.durationMs += metrics.durationMs
         window.maxQueuedDeltaMs = Math.max(
             window.maxQueuedDeltaMs,
@@ -110,11 +127,7 @@ const engine: RpgServerEngineHooks = {
                 mapId: server.getCurrentRoomId(),
                 ...window
             })
-            window.startedAt = Date.now()
-            window.ticks = 0
-            window.durationMs = 0
-            window.maxQueuedDeltaMs = 0
-            window.maxPendingInputs = 0
+            window = createMetricsWindow()
         }
     }
 }
@@ -251,7 +264,8 @@ const engine: RpgServerEngineHooks = {
     },
     
     onStep(server: RpgServerEngine) {
-        // Process global events every frame
+        // The legacy one-argument handler remains supported.
+        // This runs after each processed map tick, not after each fixed step.
         if (server.globalData.events.length > 0) {
             const event = server.globalData.events.shift()
             console.log('Processing global event:', event)

--- a/docs/internal/signe-public-boundary.snapshot.json
+++ b/docs/internal/signe-public-boundary.snapshot.json
@@ -1678,6 +1678,7 @@
       "RpgServerRoomKind",
       "RpgServerRuntimeRoom",
       "RpgServerRuntimeStorage",
+      "RpgServerStepMetrics",
       "RpgShape",
       "RpgSyncProperty",
       "RpgSyncPropertyOptions",

--- a/packages/server/src/RpgServer.ts
+++ b/packages/server/src/RpgServer.ts
@@ -1,7 +1,7 @@
 import { MapOptions } from "./decorators/map"
 import { RpgPlayer } from "./Player/Player"
 import { type RpgMap } from "./rooms/map"
-import { RpgServerEngine } from "./RpgServerEngine"
+import type { RpgServerEngine } from "./RpgServerEngine"
 import { WorldMapConfig, RpgShape, type I18nMessages, type MapPhysicsInitContext, type MapPhysicsEntityContext, type RpgActionInput } from "@rpgjs/common"
 import { RpgEvent } from "./Player/Player"
 import type { MaybePromise, RpgMapChangeTarget, RpgPlayerSnapshot, RpgSyncSchema } from "./Player/types"
@@ -21,6 +21,27 @@ type RpgMatchMaker = unknown
 type IStoreState = unknown
 
 export type ServerDatabase = Record<string, unknown> | unknown[]
+
+/**
+ * Metrics collected after one queued server tick has been processed.
+ *
+ * The context is runtime-agnostic and can be aggregated before being exported
+ * to Cloudflare Analytics Engine, OpenTelemetry, or another metrics backend.
+ */
+export interface RpgServerStepMetrics {
+    /** Current fixed simulation tick after processing the queued delta. */
+    tick: number
+    /** Wall-clock time spent processing the queued tick, excluding the hook itself. */
+    durationMs: number
+    /** Delta passed to the queued server tick. */
+    scheduledDeltaMs: number
+    /** Delta received while this tick was processing and still waiting to run. */
+    queuedDeltaMs: number
+    /** Number of fixed simulation steps executed for this queued tick. */
+    fixedSteps: number
+    /** Total number of unprocessed player inputs after this queued tick. */
+    pendingInputs: number
+}
 
 export interface RpgServerModuleSide {
     client?: unknown
@@ -78,12 +99,15 @@ export interface RpgServerEngineHooks {
     onStart?: (server: RpgServerEngine) => MaybePromise<void>
 
     /**
-     *  At each server frame. Normally represents 60FPS
+     * After each queued map tick has been processed.
      * 
-     * @prop { (engine: RpgServerEngine) => void | Promise<void> } [onStep]
+     * @prop { (engine: RpgServerEngine, metrics: RpgServerStepMetrics) => void | Promise<void> } [onStep]
      * @memberof RpgServerEngineHooks
      */
-    onStep?: (server: RpgServerEngine) => MaybePromise<void>
+    onStep?: (
+        server: RpgServerEngine,
+        metrics: RpgServerStepMetrics,
+    ) => MaybePromise<void>
 
    /**
      * Flexible authentication function for RPGJS.

--- a/packages/server/src/RpgServer.ts
+++ b/packages/server/src/RpgServer.ts
@@ -23,21 +23,21 @@ type IStoreState = unknown
 export type ServerDatabase = Record<string, unknown> | unknown[]
 
 /**
- * Metrics collected after one queued server tick has been processed.
+ * Metrics collected after one queued map tick has been processed.
  *
  * The context is runtime-agnostic and can be aggregated before being exported
  * to Cloudflare Analytics Engine, OpenTelemetry, or another metrics backend.
  */
 export interface RpgServerStepMetrics {
-    /** Current fixed simulation tick after processing the queued delta. */
+    /** Current cumulative fixed simulation tick after processing the queued delta. */
     tick: number
-    /** Wall-clock time spent processing the queued tick, excluding the hook itself. */
+    /** Wall-clock milliseconds spent processing the queued tick, excluding the hook itself. */
     durationMs: number
-    /** Delta passed to the queued server tick. */
+    /** Delta in milliseconds passed to the queued server tick. */
     scheduledDeltaMs: number
-    /** Delta received while this tick was processing and still waiting to run. */
+    /** Delta in milliseconds received during processing and still waiting to run. */
     queuedDeltaMs: number
-    /** Number of fixed simulation steps executed for this queued tick. */
+    /** Number of fixed simulation steps executed for this queued tick; can be zero or greater. */
     fixedSteps: number
     /** Total number of unprocessed player inputs after this queued tick. */
     pendingInputs: number
@@ -99,7 +99,10 @@ export interface RpgServerEngineHooks {
     onStart?: (server: RpgServerEngine) => MaybePromise<void>
 
     /**
-     * After each queued map tick has been processed.
+     * For map rooms, after each queued map tick has been processed.
+     *
+     * A queued tick can execute zero, one, or several fixed simulation steps.
+     * The hook is not emitted for lobby rooms or inactive empty maps.
      * 
      * @prop { (engine: RpgServerEngine, metrics: RpgServerStepMetrics) => void | Promise<void> } [onStep]
      * @memberof RpgServerEngineHooks

--- a/packages/server/src/RpgServerEngine.ts
+++ b/packages/server/src/RpgServerEngine.ts
@@ -6,6 +6,8 @@ import { LobbyRoom } from "./rooms/lobby";
 import { inject } from "./core/inject";
 import { context } from "./core/context";
 import { lastValueFrom } from "rxjs";
+import type { RpgServerStepMetrics } from "./RpgServer";
+import { registerServerStepEmitter } from "./server-step";
 
 /** Persistent storage available to the RPGJS server runtime. */
 export interface RpgServerRuntimeStorage {
@@ -97,6 +99,26 @@ export type RpgServerCompatibilityIo = unknown;
 export class RpgServerEngine extends RpgRoomServerBase {
   rooms = [RpgMap, LobbyRoom];
   private _globalConfig: any = {};
+
+  constructor(room: RpgServerRuntimeRoom) {
+    super(room);
+    registerServerStepEmitter(room, (metrics) => this.emitServerStep(metrics));
+  }
+
+  private async emitServerStep(metrics: RpgServerStepMetrics): Promise<void> {
+    let hooks: Hooks;
+
+    try {
+      hooks = inject<Hooks>(ModulesToken, context);
+    }
+    catch {
+      return;
+    }
+
+    await lastValueFrom(
+      hooks.callHooks("server-engine-onStep", this, metrics),
+    );
+  }
 
   /**
    * Optional compatibility handle for integrations that still expose an

--- a/packages/server/src/rooms/map.ts
+++ b/packages/server/src/rooms/map.ts
@@ -45,6 +45,7 @@ import type { RpgWritableSignal } from "@rpgjs/common";
 import { buildSaveSlotMeta, resolveSaveStorageStrategy } from "../services/save";
 import { Log } from "../logs/log";
 import { createMapUpdateHeaders, isMapUpdateAuthorized, MAP_UPDATE_TOKEN_ENV, MAP_UPDATE_TOKEN_HEADER } from "../map-update";
+import { emitServerStep } from "../server-step";
 import { RpgMapProjectiles } from "../projectiles";
 import type { DamageFormulas } from "../Player/BattleManager";
 import {
@@ -2534,7 +2535,9 @@ export class RpgMap extends RpgCommonMap<RpgPlayer> {
     this.stopServerTickLoop();
     const loopVersion = ++this._serverTickLoopVersion;
     this.tickSubscription = this.tick$.subscribe(({ delta }) => {
-      void this.runQueuedServerTick(delta, loopVersion);
+      void this.runQueuedServerTick(delta, loopVersion).catch((error) => {
+        console.error("[RPGJS] Error during server tick:", error);
+      });
     });
   }
 
@@ -2561,7 +2564,17 @@ export class RpgMap extends RpgCommonMap<RpgPlayer> {
       while (this._queuedServerTickDelta > 0 && loopVersion === this._serverTickLoopVersion) {
         const nextDelta = this._queuedServerTickDelta;
         this._queuedServerTickDelta = 0;
-        await this.runServerTick(nextDelta);
+        const startedAt = this.getServerTickTime();
+        const fixedSteps = await this.runServerTick(nextDelta);
+        const durationMs = Math.max(0, this.getServerTickTime() - startedAt);
+        await emitServerStep(this.partyRoom, {
+          tick: this.getTick(),
+          durationMs,
+          scheduledDeltaMs: nextDelta,
+          queuedDeltaMs: this._queuedServerTickDelta,
+          fixedSteps,
+          pendingInputs: this.getPendingInputCount(),
+        });
       }
     }
     finally {
@@ -2590,6 +2603,22 @@ export class RpgMap extends RpgCommonMap<RpgPlayer> {
         anyPlayer._isProcessingInputs = false;
       }
     }
+  }
+
+  private getServerTickTime(): number {
+    const performanceNow = globalThis.performance?.now?.();
+    return typeof performanceNow === "number" && Number.isFinite(performanceNow)
+      ? performanceNow
+      : Date.now();
+  }
+
+  private getPendingInputCount(): number {
+    return this.getPlayers().reduce(
+      (total, player) => total + (
+        Array.isArray(player.pendingInputs) ? player.pendingInputs.length : 0
+      ),
+      0,
+    );
   }
 
   async nextTickAsync(deltaMs?: number): Promise<number> {

--- a/packages/server/src/server-step.ts
+++ b/packages/server/src/server-step.ts
@@ -1,0 +1,25 @@
+import type { RpgServerStepMetrics } from "./RpgServer";
+
+type ServerStepEmitter = (metrics: RpgServerStepMetrics) => Promise<void>;
+
+const serverStepEmitters = new WeakMap<object, ServerStepEmitter>();
+
+export function registerServerStepEmitter(
+  room: object | null | undefined,
+  emitter: ServerStepEmitter,
+): void {
+  if (!room || (typeof room !== "object" && typeof room !== "function")) {
+    return;
+  }
+  serverStepEmitters.set(room, emitter);
+}
+
+export async function emitServerStep(
+  room: object | null | undefined,
+  metrics: RpgServerStepMetrics,
+): Promise<void> {
+  if (!room || (typeof room !== "object" && typeof room !== "function")) {
+    return;
+  }
+  await serverStepEmitters.get(room)?.(metrics);
+}

--- a/packages/server/tests/server-api-types.spec.ts
+++ b/packages/server/tests/server-api-types.spec.ts
@@ -15,6 +15,8 @@ import type {
   RpgPlayerSnapshot,
   RpgPlayerSnapshotLoadResult,
   RpgServerEngine,
+  RpgServerEngineHooks,
+  RpgServerStepMetrics,
   StateData,
   ServerMapStreamingAdapter,
 } from "@rpgjs/server";
@@ -181,6 +183,23 @@ describe("server public API types", () => {
     };
 
     expectTypeOf(assertions).toBeFunction();
+  });
+
+  test("server step hooks expose metrics without breaking one-argument handlers", () => {
+    const hooks = {
+      onStep(server, metrics) {
+        expectTypeOf(server).toEqualTypeOf<RpgServerEngine>();
+        expectTypeOf(metrics).toEqualTypeOf<RpgServerStepMetrics>();
+      },
+    } satisfies RpgServerEngineHooks;
+    const legacyHooks = {
+      onStep(server) {
+        expectTypeOf(server).toEqualTypeOf<RpgServerEngine>();
+      },
+    } satisfies RpgServerEngineHooks;
+
+    expectTypeOf(hooks).toMatchTypeOf<RpgServerEngineHooks>();
+    expectTypeOf(legacyHooks).toMatchTypeOf<RpgServerEngineHooks>();
   });
 
   test("legacy Signe root re-exports are not part of the stable API", () => {

--- a/packages/server/tests/server-step-metrics.spec.ts
+++ b/packages/server/tests/server-step-metrics.spec.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createServer, provideServerModules } from "../src";
+import type {
+  RpgServerEngine,
+  RpgServerStepMetrics,
+} from "../src";
+import {
+  createRpgServerTransport,
+  type RpgServerTransport,
+} from "../src/node";
+
+function wait(ms = 0): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+class MockWebSocket {
+  readyState = 1;
+  sent: string[] = [];
+  private handlers = new Map<string, Array<(...args: any[]) => void>>();
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.readyState = 3;
+    this.emit("close");
+  }
+
+  on(event: string, callback: (...args: any[]) => void): void {
+    const listeners = this.handlers.get(event) || [];
+    listeners.push(callback);
+    this.handlers.set(event, listeners);
+  }
+
+  emit(event: string, ...args: any[]): void {
+    for (const callback of this.handlers.get(event) || []) {
+      callback(...args);
+    }
+  }
+}
+
+describe("server step metrics", () => {
+  let transport: RpgServerTransport;
+  let map: any;
+  let socket: MockWebSocket | undefined;
+  let onStep: ReturnType<typeof vi.fn>;
+  let legacyOnStep: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    onStep = vi.fn();
+    legacyOnStep = vi.fn();
+    const GameServer = createServer({
+      providers: [
+        provideServerModules([
+          {
+            engine: {
+              onStep(
+                server: RpgServerEngine,
+                metrics: RpgServerStepMetrics,
+              ) {
+                onStep(server, metrics);
+              },
+            },
+          },
+          {
+            engine: {
+              onStep(server: RpgServerEngine) {
+                legacyOnStep(server);
+              },
+            },
+          },
+        ]),
+      ],
+    });
+    transport = createRpgServerTransport(GameServer, {
+      initializeMaps: false,
+    });
+
+    const response = await transport.updateMap("metrics", {
+      id: "metrics",
+      width: 320,
+      height: 240,
+      events: [],
+    });
+    expect(response.ok).toBe(true);
+    map = transport.getServer("map-metrics")!.getCurrentRoom<any>();
+  });
+
+  afterEach(async () => {
+    socket?.close();
+    map?.setAutoTick(false);
+    await wait();
+    vi.restoreAllMocks();
+  });
+
+  async function connectPlayer(): Promise<void> {
+    socket = new MockWebSocket();
+    expect(await transport.acceptWebSocket(socket as any, {
+      url: "http://localhost/parties/main/map-metrics?id=metrics-player",
+      method: "GET",
+      headers: {
+        host: "localhost",
+      },
+    })).toBe(true);
+    await wait(10);
+  }
+
+  it("emits typed metrics from the automatic map tick loop", async () => {
+    await connectPlayer();
+
+    await vi.waitFor(() => {
+      expect(onStep).toHaveBeenCalled();
+    }, { timeout: 500 });
+
+    const [server, metrics] = onStep.mock.calls.at(-1)!;
+    expect(server).toBe(transport.getServer("map-metrics"));
+    expect(metrics).toEqual({
+      tick: expect.any(Number),
+      durationMs: expect.any(Number),
+      scheduledDeltaMs: expect.any(Number),
+      queuedDeltaMs: expect.any(Number),
+      fixedSteps: expect.any(Number),
+      pendingInputs: expect.any(Number),
+    });
+    expect(metrics.durationMs).toBeGreaterThanOrEqual(0);
+    expect(metrics.scheduledDeltaMs).toBeGreaterThan(0);
+    expect(metrics.tick).toBeGreaterThan(0);
+    expect(metrics.tick).toBeLessThanOrEqual(map.getTick());
+    expect(legacyOnStep).toHaveBeenCalledWith(server);
+  });
+
+  it("reports queued delta and pending inputs until delayed processing recovers", async () => {
+    await connectPlayer();
+    map.setAutoTick(false);
+    onStep.mockClear();
+
+    const player = map.getPlayers()[0];
+    player.pendingInputs = [{ frame: 1 }];
+    let releaseFirstTick!: () => void;
+    const firstTickGate = new Promise<void>((resolve) => {
+      releaseFirstTick = resolve;
+    });
+    const runServerTick = vi.spyOn(map, "runServerTick");
+    runServerTick
+      .mockImplementationOnce(async () => {
+        await firstTickGate;
+        return 1;
+      })
+      .mockImplementationOnce(async () => {
+        player.pendingInputs = [];
+        return 1;
+      });
+
+    const processing = map.runQueuedServerTick(17);
+    await wait();
+    await map.runQueuedServerTick(23);
+    releaseFirstTick();
+    await processing;
+
+    expect(onStep).toHaveBeenCalledTimes(2);
+    expect(onStep.mock.calls[0][1]).toMatchObject({
+      scheduledDeltaMs: 17,
+      queuedDeltaMs: 23,
+      fixedSteps: 1,
+      pendingInputs: 1,
+    });
+    expect(onStep.mock.calls[1][1]).toMatchObject({
+      scheduledDeltaMs: 23,
+      queuedDeltaMs: 0,
+      fixedSteps: 1,
+      pendingInputs: 0,
+    });
+  });
+
+  it("does not emit step hooks while an empty map loop is stopped", async () => {
+    expect(Array.from(
+      transport.getRoom("map-metrics")!.getConnections(),
+    )).toHaveLength(0);
+    expect(map.tickSubscription).toBeFalsy();
+
+    await wait(40);
+
+    expect(onStep).not.toHaveBeenCalled();
+  });
+
+  it("stops emitting after the last player disconnects", async () => {
+    await connectPlayer();
+    await vi.waitFor(() => {
+      expect(onStep).toHaveBeenCalled();
+    }, { timeout: 500 });
+
+    socket!.close();
+    await vi.waitFor(() => {
+      expect(map.tickSubscription).toBeFalsy();
+    }, { timeout: 500 });
+    onStep.mockClear();
+    await wait(40);
+
+    expect(onStep).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Résumé

- appelle le hook documenté `engine.onStep` après chaque tick serveur mis en file
- expose le contexte typé `RpgServerStepMetrics` (`durationMs`, backlog, fixed steps et entrées en attente)
- conserve la compatibilité des handlers historiques `onStep(server)`
- n’ajoute aucun timer : les rooms vides gardent leur boucle automatique arrêtée
- documente l’agrégation des métriques avant export et ajoute le changeset `patch`

## Cause

Le hook `onStep` était présent dans l’API publique et la documentation, mais aucun événement `server-engine-onStep` n’était émis depuis la boucle de tick des maps.

## Vérifications

- `pnpm exec vitest run --reporter=dot` — 152 fichiers, 1 108 tests réussis, 19 ignorés
- tests ciblés — 15 tests réussis
- `pnpm test:types`
- `pnpm build`
- `pnpm api:boundary`
- tests et builds de `samples/cloudflare-mmorpg`
- tests et build Cloudflare de `playground/games/studio`

Fixes #330