### PR TITLE
fix: render streamed Studio terrain incrementally

### DIFF
--- a/.changeset/fuzzy-terrain-streaming.md
+++ b/.changeset/fuzzy-terrain-streaming.md
@@ -1,0 +1,5 @@
+---
+"@rpgjs/studio": patch
+---
+
+Render only terrain chunks affected by consolidated Studio map stream updates.

--- a/packages/studio/src/client-provider.ts
+++ b/packages/studio/src/client-provider.ts
@@ -6,6 +6,7 @@ import loadMap from "./map-loader";
 import {
   applyStudioMapStreamChunk,
   createStudioMapStreamState,
+  getStudioMapStreamData,
   removeStudioMapStreamChunk,
   type StudioMapStreamChunkData,
   type StudioMapStreamManifestData,
@@ -23,7 +24,7 @@ export function createStudioMapClientProviders(): any[] {
       createState: createStudioMapStreamState,
       applyChunk: applyStudioMapStreamChunk,
       removeChunk: removeStudioMapStreamChunk,
-      getData: (state) => state.map,
+      getData: getStudioMapStreamData,
       getParams: (manifest) => ({
         backgroundMusic: manifest.renderData.map.params?.backgroundMusic,
         backgroundAmbientSound:

--- a/packages/studio/src/map-renderer/components/studio-terrain-map.ce
+++ b/packages/studio/src/map-renderer/components/studio-terrain-map.ce
@@ -53,11 +53,10 @@ const renderTerrain = async () => {
   const currentSerial = ++renderSerial
   await terrainRenderer.renderMap(mapData, {
     debugCollisions: readValue(debugCollisions) === true,
-    splitWallForeground: readValue(splitWallForeground) === true
+    splitWallForeground: readValue(splitWallForeground) === true,
+    streamUpdate: mapData.terrainRenderData?.streamUpdate
   })
   if (currentSerial !== renderSerial) {
-    terrainRenderer.invalidateTerrain()
-    lastCullKey = ""
     return
   }
   lastCullKey = ""

--- a/packages/studio/src/map-renderer/index.ts
+++ b/packages/studio/src/map-renderer/index.ts
@@ -5,5 +5,7 @@ export type {
   StudioCollisionPolygon,
   StudioTerrainCell,
   StudioTerrainMorphologyFeature,
+  StudioTerrainRenderBounds,
   StudioTerrainRenderData,
+  StudioTerrainStreamUpdate,
 } from "./types";

--- a/packages/studio/src/map-renderer/terrain-renderer/terrain-chunk-renderer.spec.ts
+++ b/packages/studio/src/map-renderer/terrain-renderer/terrain-chunk-renderer.spec.ts
@@ -1,5 +1,50 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { StudioTerrainChunkRenderer } from "./terrain-chunk-renderer";
+
+function createTerrainMap(width = 2304, height = 768) {
+  return {
+    terrainRenderData: {
+      widthTiles: width / 48,
+      heightTiles: height / 48,
+      tileSize: 48,
+      width,
+      height,
+      asset: null,
+      sourceTexture: "",
+      terrainControl: null,
+      terrainGrid: [],
+      morphologyFeatures: [],
+      waterAnimation: {
+        enabled: false,
+        speed: 1,
+        intensity: 0,
+        direction: 0,
+      },
+      version: "streamed:revision-1:1",
+    },
+  };
+}
+
+function createInstrumentedRenderer() {
+  const renderer = new StudioTerrainChunkRenderer(
+    { sortableChildren: false } as any,
+    { chunkSize: 768 }
+  );
+  const renderChunk = vi
+    .spyOn(renderer as any, "renderChunk")
+    .mockImplementation((...args: unknown[]) => {
+      const [key, , , , bounds] = args as [string, unknown, unknown, unknown, any];
+      (renderer as any).chunks.set(key, {
+        key,
+        ...bounds,
+        sprite: { destroyed: false, visible: true },
+      });
+    });
+  const destroyChunk = vi
+    .spyOn(renderer as any, "destroyChunk")
+    .mockImplementation(() => undefined);
+  return { renderer, renderChunk, destroyChunk };
+}
 
 describe("StudioTerrainChunkRenderer terrain control cache", () => {
   it("does not reuse a buffer when region content changes after the base64 prefix", () => {
@@ -29,5 +74,119 @@ describe("StudioTerrainChunkRenderer terrain control cache", () => {
 
     expect(second).not.toBe(first);
     expect(Array.from(second.data)).not.toEqual(Array.from(first.data));
+  });
+});
+
+describe("StudioTerrainChunkRenderer streamed invalidation", () => {
+  it("renders only active chunks and preserves chunks outside a dirty region", async () => {
+    const { renderer, renderChunk, destroyChunk } = createInstrumentedRenderer();
+    const map = createTerrainMap();
+    const firstUpdate = {
+      revision: "revision-1",
+      generation: 1,
+      dirtyRegions: [{ x: 0, y: 0, width: 1536, height: 768 }],
+      activeRegions: [{ x: 0, y: 0, width: 1536, height: 768 }],
+    };
+
+    await renderer.renderMap(map, { streamUpdate: firstUpdate });
+    expect(renderChunk.mock.calls.map(([key]) => key)).toEqual(["0:0", "1:0"]);
+    const firstChunk = (renderer as any).chunks.get("0:0");
+
+    renderChunk.mockClear();
+    map.terrainRenderData.version = "streamed:revision-1:2";
+    await renderer.renderMap(map, {
+      streamUpdate: {
+        ...firstUpdate,
+        generation: 2,
+        dirtyRegions: [{ x: 768, y: 0, width: 768, height: 768 }],
+      },
+    });
+
+    expect(renderChunk.mock.calls.map(([key]) => key)).toEqual(["1:0"]);
+    expect((renderer as any).chunks.get("0:0")).toBe(firstChunk);
+    expect(destroyChunk).not.toHaveBeenCalled();
+  });
+
+  it("destroys an evicted renderer chunk without rebuilding retained chunks", async () => {
+    const { renderer, renderChunk, destroyChunk } = createInstrumentedRenderer();
+    const map = createTerrainMap();
+    const firstUpdate = {
+      revision: "revision-1",
+      generation: 1,
+      dirtyRegions: [{ x: 0, y: 0, width: 1536, height: 768 }],
+      activeRegions: [{ x: 0, y: 0, width: 1536, height: 768 }],
+    };
+    await renderer.renderMap(map, { streamUpdate: firstUpdate });
+    const retainedChunk = (renderer as any).chunks.get("0:0");
+    const removedChunk = (renderer as any).chunks.get("1:0");
+
+    renderChunk.mockClear();
+    map.terrainRenderData.version = "streamed:revision-1:2";
+    await renderer.renderMap(map, {
+      streamUpdate: {
+        revision: "revision-1",
+        generation: 2,
+        dirtyRegions: [{ x: 768, y: 0, width: 768, height: 768 }],
+        activeRegions: [{ x: 0, y: 0, width: 768, height: 768 }],
+      },
+    });
+
+    expect(renderChunk).not.toHaveBeenCalled();
+    expect(destroyChunk).toHaveBeenCalledWith(removedChunk);
+    expect((renderer as any).chunks.get("0:0")).toBe(retainedChunk);
+    expect((renderer as any).chunks.has("1:0")).toBe(false);
+  });
+
+  it("uses half-open dirty bounds and fully refreshes a new revision", async () => {
+    const { renderer, renderChunk } = createInstrumentedRenderer();
+    const map = createTerrainMap();
+    await renderer.renderMap(map, {
+      streamUpdate: {
+        revision: "revision-1",
+        generation: 1,
+        dirtyRegions: [{ x: 0, y: 0, width: 768, height: 768 }],
+        activeRegions: [{ x: 0, y: 0, width: 2304, height: 768 }],
+      },
+    });
+    expect(renderChunk.mock.calls.map(([key]) => key)).toEqual([
+      "0:0",
+      "1:0",
+      "2:0",
+    ]);
+
+    renderChunk.mockClear();
+    map.terrainRenderData.version = "streamed:revision-1:2";
+    await renderer.renderMap(map, {
+      streamUpdate: {
+        revision: "revision-1",
+        generation: 2,
+        dirtyRegions: [{ x: 0, y: 0, width: 768, height: 768 }],
+        activeRegions: [{ x: 0, y: 0, width: 2304, height: 768 }],
+      },
+    });
+    expect(renderChunk.mock.calls.map(([key]) => key)).toEqual(["0:0"]);
+
+    renderChunk.mockClear();
+    map.terrainRenderData.version = "streamed:revision-2:1";
+    await renderer.renderMap(map, {
+      streamUpdate: {
+        revision: "revision-2",
+        generation: 1,
+        dirtyRegions: [{ x: 1536, y: 0, width: 768, height: 768 }],
+        activeRegions: [{ x: 1536, y: 0, width: 768, height: 768 }],
+      },
+    });
+    expect(renderChunk.mock.calls.map(([key]) => key)).toEqual(["2:0"]);
+    expect([...(renderer as any).chunks.keys()]).toEqual(["2:0"]);
+  });
+
+  it("keeps full-map rendering for non-streamed terrain", async () => {
+    const { renderer, renderChunk } = createInstrumentedRenderer();
+    await renderer.renderMap(createTerrainMap());
+    expect(renderChunk.mock.calls.map(([key]) => key)).toEqual([
+      "0:0",
+      "1:0",
+      "2:0",
+    ]);
   });
 });

--- a/packages/studio/src/map-renderer/terrain-renderer/terrain-chunk-renderer.ts
+++ b/packages/studio/src/map-renderer/terrain-renderer/terrain-chunk-renderer.ts
@@ -9,7 +9,9 @@ import {
   type StudioCollisionPolygon,
   type StudioTerrainControlTexture,
   type StudioTerrainMorphologyFeature,
+  type StudioTerrainRenderBounds,
   type StudioTerrainRenderData,
+  type StudioTerrainStreamUpdate,
   type StudioWaterAnimationOptions,
 } from "../types";
 import {
@@ -173,9 +175,14 @@ export interface StudioTerrainWallShadowStyle {
 }
 
 export interface StudioTerrainChunkRendererOptions {
+  /** Renderer chunk size in world pixels. */
   chunkSize?: number;
+  /** Draw collision polygons into regenerated terrain chunks. */
   debugCollisions?: boolean;
+  /** Render wall foreground separately from the terrain base. */
   splitWallForeground?: boolean;
+  /** Consolidated client stream update used for spatial invalidation. */
+  streamUpdate?: StudioTerrainStreamUpdate | null;
 }
 
 export class StudioTerrainChunkRenderer {
@@ -187,6 +194,9 @@ export class StudioTerrainChunkRenderer {
   private imageBufferCache = new Map<string, ImageBuffer>();
   private patternCache = new Map<string, HTMLCanvasElement>();
   private renderVersion = "";
+  private renderConfiguration = "";
+  private streamRevision = "";
+  private streamGeneration = -1;
   private destroyed = false;
   private viewportBounds: TerrainViewportBounds | null = null;
   private viewportMargin = 0;
@@ -207,32 +217,67 @@ export class StudioTerrainChunkRenderer {
       : createStudioTerrainRenderData(map);
     const debugCollisions = options.debugCollisions === true;
     const splitWallForeground = options.splitWallForeground === true;
-    const version = `${data.version}|debug:${debugCollisions}|chunk:${this.chunkSize}|splitWall:${splitWallForeground}`;
-    if (version === this.renderVersion && this.chunks.size > 0) return;
+    const configuration = `debug:${debugCollisions}|chunk:${this.chunkSize}|splitWall:${splitWallForeground}`;
+    const version = `${data.version}|${configuration}`;
+    const streamUpdate = options.streamUpdate ?? data.streamUpdate ?? null;
+    if (!streamUpdate && version === this.renderVersion && this.chunks.size > 0) return;
+    if (
+      streamUpdate &&
+      version === this.renderVersion &&
+      configuration === this.renderConfiguration &&
+      streamUpdate.revision === this.streamRevision &&
+      streamUpdate.generation === this.streamGeneration
+    ) {
+      return;
+    }
+    const renderAllActiveStreamChunks = Boolean(
+      streamUpdate &&
+        (
+          !this.renderVersion ||
+          configuration !== this.renderConfiguration ||
+          streamUpdate.revision !== this.streamRevision
+        )
+    );
     this.renderVersion = version;
+    this.renderConfiguration = configuration;
+    this.streamRevision = streamUpdate?.revision ?? "";
+    this.streamGeneration = streamUpdate?.generation ?? -1;
 
     const image = data.sourceTexture ? this.loadedImages.get(data.sourceTexture) ?? null : null;
     const controlImage = data.terrainControl?.source
       ? this.loadedImages.get(data.terrainControl.source) ?? null
       : null;
 
-    const nextKeys = new Set<string>();
+    const activeKeys = streamUpdate
+      ? this.collectChunkKeys(streamUpdate.activeRegions, data)
+      : null;
+    const nextKeys = streamUpdate
+      ? renderAllActiveStreamChunks
+        ? activeKeys!
+        : this.collectChunkKeys(streamUpdate.dirtyRegions, data)
+      : this.collectAllChunkKeys(data);
     const collisions = debugCollisions ? buildStudioTerrainCollisionPolygons(map) : [];
-    const columns = Math.max(1, Math.ceil(data.width / this.chunkSize));
-    const rows = Math.max(1, Math.ceil(data.height / this.chunkSize));
 
     this.resetMorphologyRenderCaches();
     try {
-      for (let row = 0; row < rows; row += 1) {
-        for (let column = 0; column < columns; column += 1) {
-          const x = column * this.chunkSize;
-          const y = row * this.chunkSize;
-          const width = Math.min(this.chunkSize, data.width - x);
-          const height = Math.min(this.chunkSize, data.height - y);
-          const key = `${column}:${row}`;
-          nextKeys.add(key);
-          this.renderChunk(key, data, image, controlImage, { x, y, width, height }, collisions, splitWallForeground);
+      for (const key of nextKeys) {
+        if (activeKeys && !activeKeys.has(key)) {
+          const previous = this.chunks.get(key);
+          if (previous) {
+            this.destroyChunk(previous);
+            this.chunks.delete(key);
+          }
+          continue;
         }
+        this.renderChunk(
+          key,
+          data,
+          image,
+          controlImage,
+          this.getChunkBounds(key, data),
+          collisions,
+          splitWallForeground
+        );
       }
     } finally {
       this.resetMorphologyRenderCaches();
@@ -241,6 +286,16 @@ export class StudioTerrainChunkRenderer {
     if (data.sourceTexture && !image) {
       void this.loadImage(data.sourceTexture).then((loadedImage) => {
         if (!loadedImage || this.destroyed) return;
+        if (
+          this.renderVersion !== version ||
+          (streamUpdate &&
+            (
+              this.streamRevision !== streamUpdate.revision ||
+              this.streamGeneration !== streamUpdate.generation
+            ))
+        ) {
+          return;
+        }
         this.renderVersion = "";
         void this.renderMap(map, options);
       });
@@ -252,19 +307,91 @@ export class StudioTerrainChunkRenderer {
     ) {
       void this.loadImage(data.terrainControl.source).then((loadedImage) => {
         if (!loadedImage || this.destroyed) return;
+        if (
+          this.renderVersion !== version ||
+          (streamUpdate &&
+            (
+              this.streamRevision !== streamUpdate.revision ||
+              this.streamGeneration !== streamUpdate.generation
+            ))
+        ) {
+          return;
+        }
         this.renderVersion = "";
         void this.renderMap(map, options);
       });
     }
 
-    for (const [key, chunk] of this.chunks) {
-      if (!nextKeys.has(key)) {
-        this.destroyChunk(chunk);
-        this.chunks.delete(key);
+    if (!streamUpdate || renderAllActiveStreamChunks) {
+      const retainedKeys = activeKeys ?? nextKeys;
+      for (const [key, chunk] of this.chunks) {
+        if (!retainedKeys.has(key)) {
+          this.destroyChunk(chunk);
+          this.chunks.delete(key);
+        }
       }
     }
 
     this.updateChunkVisibility(this.viewportBounds, this.viewportMargin);
+  }
+
+  private collectAllChunkKeys(data: StudioTerrainRenderData): Set<string> {
+    const keys = new Set<string>();
+    const columns = Math.max(1, Math.ceil(data.width / this.chunkSize));
+    const rows = Math.max(1, Math.ceil(data.height / this.chunkSize));
+    for (let row = 0; row < rows; row += 1) {
+      for (let column = 0; column < columns; column += 1) {
+        keys.add(`${column}:${row}`);
+      }
+    }
+    return keys;
+  }
+
+  private collectChunkKeys(
+    regions: StudioTerrainRenderBounds[],
+    data: StudioTerrainRenderData
+  ): Set<string> {
+    const keys = new Set<string>();
+    const columns = Math.max(1, Math.ceil(data.width / this.chunkSize));
+    const rows = Math.max(1, Math.ceil(data.height / this.chunkSize));
+    for (const region of regions) {
+      const left = Math.max(0, Math.min(data.width, Number(region.x) || 0));
+      const top = Math.max(0, Math.min(data.height, Number(region.y) || 0));
+      const right = Math.max(
+        left,
+        Math.min(data.width, (Number(region.x) || 0) + (Number(region.width) || 0))
+      );
+      const bottom = Math.max(
+        top,
+        Math.min(data.height, (Number(region.y) || 0) + (Number(region.height) || 0))
+      );
+      if (right <= left || bottom <= top) continue;
+      const minColumn = Math.floor(left / this.chunkSize);
+      const minRow = Math.floor(top / this.chunkSize);
+      const maxColumn = Math.min(columns - 1, Math.ceil(right / this.chunkSize) - 1);
+      const maxRow = Math.min(rows - 1, Math.ceil(bottom / this.chunkSize) - 1);
+      for (let row = minRow; row <= maxRow; row += 1) {
+        for (let column = minColumn; column <= maxColumn; column += 1) {
+          keys.add(`${column}:${row}`);
+        }
+      }
+    }
+    return keys;
+  }
+
+  private getChunkBounds(
+    key: string,
+    data: StudioTerrainRenderData
+  ): StudioTerrainRenderBounds {
+    const [column, row] = key.split(":").map(Number);
+    const x = column * this.chunkSize;
+    const y = row * this.chunkSize;
+    return {
+      x,
+      y,
+      width: Math.min(this.chunkSize, data.width - x),
+      height: Math.min(this.chunkSize, data.height - y),
+    };
   }
 
   updateChunkVisibility(bounds?: TerrainViewportBounds | null, margin = 0): void {
@@ -320,8 +447,8 @@ export class StudioTerrainChunkRenderer {
     }
     const minX = Math.floor(bounds.x / this.chunkSize);
     const minY = Math.floor(bounds.y / this.chunkSize);
-    const maxX = Math.floor((bounds.x + bounds.width) / this.chunkSize);
-    const maxY = Math.floor((bounds.y + bounds.height) / this.chunkSize);
+    const maxX = Math.ceil((bounds.x + bounds.width) / this.chunkSize) - 1;
+    const maxY = Math.ceil((bounds.y + bounds.height) / this.chunkSize) - 1;
     for (let y = minY; y <= maxY; y += 1) {
       for (let x = minX; x <= maxX; x += 1) {
         const chunk = this.chunks.get(`${x}:${y}`);
@@ -343,6 +470,10 @@ export class StudioTerrainChunkRenderer {
     this.patternCache.clear();
     this.imageBufferCache.clear();
     this.viewportBounds = null;
+    this.renderVersion = "";
+    this.renderConfiguration = "";
+    this.streamRevision = "";
+    this.streamGeneration = -1;
     this.resetMorphologyRenderCaches();
     this.world.removeChildren();
   }

--- a/packages/studio/src/map-renderer/types.ts
+++ b/packages/studio/src/map-renderer/types.ts
@@ -87,6 +87,28 @@ export interface StudioTerrainMorphologyFeature {
   operations?: StudioTerrainMorphologyOperation[];
 }
 
+export interface StudioTerrainRenderBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Client-only invalidation data produced after an authoritative Studio stream
+ * packet has been consolidated.
+ */
+export interface StudioTerrainStreamUpdate {
+  /** Authoritative map revision represented by the active chunks. */
+  revision: string;
+  /** Monotonic client generation incremented once per consolidated packet. */
+  generation: number;
+  /** Terrain regions whose disclosed content changed in this generation. */
+  dirtyRegions: StudioTerrainRenderBounds[];
+  /** Terrain regions represented by all chunks currently retained by the client. */
+  activeRegions: StudioTerrainRenderBounds[];
+}
+
 export interface StudioTerrainRenderData {
   widthTiles: number;
   heightTiles: number;
@@ -100,6 +122,8 @@ export interface StudioTerrainRenderData {
   morphologyFeatures: StudioTerrainMorphologyFeature[];
   waterAnimation: StudioWaterAnimationOptions;
   version: string;
+  /** Incremental invalidation state for streamed maps; absent for direct loads. */
+  streamUpdate?: StudioTerrainStreamUpdate;
 }
 
 /**

--- a/packages/studio/src/map-streaming.spec.ts
+++ b/packages/studio/src/map-streaming.spec.ts
@@ -3,6 +3,7 @@ import {
   applyStudioMapStreamChunk,
   compileStudioMapStream,
   createStudioMapStreamState,
+  getStudioMapStreamData,
   isStudioDirectLoadPayload,
   prepareStudioMapPayload,
   removeStudioMapStreamChunk,
@@ -141,20 +142,72 @@ describe("Studio authoritative map streaming", () => {
     const state = createStudioMapStreamState(definition.manifest);
     const initialVersion = state.map.terrainRenderData.version;
     applyStudioMapStreamChunk(state, definition.chunks["0:0"]);
-    expect(state.map.terrainRenderData.terrainControl.regions)
+    const map = getStudioMapStreamData(state);
+    expect(map.terrainRenderData.terrainControl.regions)
       .toEqual([definition.chunks["0:0"].renderData.terrainControlRegion]);
-    expect(state.map.terrainRenderData.version).not.toBe(initialVersion);
+    expect(map.terrainRenderData.version).not.toBe(initialVersion);
   });
 
-  it("rebuilds the render state when chunks enter and leave", () => {
+  it("consolidates chunk deltas into one render generation", () => {
     const definition = compileStudioMapStream(
       prepareStudioMapPayload(createMap()),
       { chunkSize: 2 }
     );
     const state = createStudioMapStreamState(definition.manifest);
+    applyStudioMapStreamChunk(state, definition.chunks["0:0"]);
     applyStudioMapStreamChunk(state, definition.chunks["1:0"]);
-    expect(state.map.elementsLow).toHaveLength(1);
-    removeStudioMapStreamChunk(state, "1:0");
+    expect(state.generation).toBe(0);
     expect(state.map.elementsLow).toHaveLength(0);
+
+    const enteredMap = getStudioMapStreamData(state);
+    expect(state.generation).toBe(1);
+    expect(enteredMap.elementsLow).toHaveLength(1);
+    expect(enteredMap.terrainRenderData.streamUpdate).toMatchObject({
+      revision: definition.manifest.revision,
+      generation: 1,
+    });
+    expect(enteredMap.terrainRenderData.streamUpdate.dirtyRegions).toHaveLength(2);
+    expect(enteredMap.terrainRenderData.streamUpdate.activeRegions).toHaveLength(2);
+    expect(getStudioMapStreamData(state)).toBe(enteredMap);
+    expect(state.generation).toBe(1);
+
+    removeStudioMapStreamChunk(state, "1:0");
+    expect(state.map).toBe(enteredMap);
+    const removedMap = getStudioMapStreamData(state);
+    expect(state.generation).toBe(2);
+    expect(removedMap.elementsLow).toHaveLength(0);
+    expect(removedMap.terrainRenderData.streamUpdate).toMatchObject({
+      generation: 2,
+      activeRegions: [expect.any(Object)],
+      dirtyRegions: [expect.any(Object)],
+    });
+  });
+
+  it("invalidates an updated chunk even when its key is unchanged", () => {
+    const definition = compileStudioMapStream(
+      prepareStudioMapPayload(createMap()),
+      { chunkSize: 2 }
+    );
+    const state = createStudioMapStreamState(definition.manifest);
+    applyStudioMapStreamChunk(state, definition.chunks["0:0"]);
+    getStudioMapStreamData(state);
+
+    applyStudioMapStreamChunk(state, {
+      ...definition.chunks["0:0"],
+      renderData: {
+        ...definition.chunks["0:0"].renderData,
+        terrainCells: [],
+      },
+    });
+    const map = getStudioMapStreamData(state);
+
+    expect(map.terrainRenderData.streamUpdate.generation).toBe(2);
+    expect(map.terrainRenderData.streamUpdate.dirtyRegions).toHaveLength(2);
+    expect(map.terrainRenderData.streamUpdate.dirtyRegions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ width: 96 }),
+        expect.objectContaining({ width: 192 }),
+      ])
+    );
   });
 });

--- a/packages/studio/src/map-streaming.ts
+++ b/packages/studio/src/map-streaming.ts
@@ -11,7 +11,10 @@ import {
   buildStudioTerrainCollisionPolygons,
   createStudioTerrainRenderData,
 } from "./map-renderer";
-import type { StudioTerrainControlRegion } from "./map-renderer/types";
+import type {
+  StudioTerrainControlRegion,
+  StudioTerrainRenderBounds,
+} from "./map-renderer/types";
 import { resolveStudioElementSize } from "./studio-element-size";
 
 type StudioElementLayer = "elementsAlwaysLow" | "elementsLow" | "elementsHigh";
@@ -31,6 +34,9 @@ export interface StudioMapStreamState {
   manifest: MapStreamManifest<StudioMapStreamManifestData>;
   chunks: Map<string, MapStreamChunk<StudioMapStreamChunkData>>;
   map: Record<string, any>;
+  generation: number;
+  needsRebuild: boolean;
+  pendingTerrainRegions: Map<string, StudioTerrainRenderBounds>;
 }
 
 export interface PreparedStudioMapPayload {
@@ -524,6 +530,62 @@ export function compileStudioMapStream(
   return { manifest, chunks };
 }
 
+function clipTerrainBounds(
+  bounds: StudioTerrainRenderBounds,
+  manifest: MapStreamManifest<StudioMapStreamManifestData>
+): StudioTerrainRenderBounds | null {
+  const x = Math.max(0, Math.min(manifest.width, bounds.x));
+  const y = Math.max(0, Math.min(manifest.height, bounds.y));
+  const right = Math.max(x, Math.min(manifest.width, bounds.x + bounds.width));
+  const bottom = Math.max(y, Math.min(manifest.height, bounds.y + bounds.height));
+  if (right <= x || bottom <= y) return null;
+  return { x, y, width: right - x, height: bottom - y };
+}
+
+function getChunkTerrainBounds(
+  state: StudioMapStreamState,
+  chunk: MapStreamChunk<StudioMapStreamChunkData>
+): StudioTerrainRenderBounds {
+  let left = chunk.bounds.x;
+  let top = chunk.bounds.y;
+  let right = chunk.bounds.x + chunk.bounds.width;
+  let bottom = chunk.bounds.y + chunk.bounds.height;
+  const include = (bounds: StudioTerrainRenderBounds): void => {
+    left = Math.min(left, bounds.x);
+    top = Math.min(top, bounds.y);
+    right = Math.max(right, bounds.x + bounds.width);
+    bottom = Math.max(bottom, bounds.y + bounds.height);
+  };
+
+  for (const [tileX, tileY] of chunk.renderData.terrainCells) {
+    include({ x: tileX * 48, y: tileY * 48, width: 48, height: 48 });
+  }
+  for (const feature of chunk.renderData.morphologyFeatures) {
+    include(featureBounds(feature));
+  }
+  if (chunk.renderData.terrainControlRegion) {
+    include(chunk.renderData.terrainControlRegion);
+  }
+
+  return (
+    clipTerrainBounds(
+      { x: left, y: top, width: right - left, height: bottom - top },
+      state.manifest
+    ) ?? { ...chunk.bounds }
+  );
+}
+
+function markTerrainRegion(
+  state: StudioMapStreamState,
+  chunk: MapStreamChunk<StudioMapStreamChunkData>
+): void {
+  const bounds = getChunkTerrainBounds(state, chunk);
+  state.pendingTerrainRegions.set(
+    `${bounds.x}:${bounds.y}:${bounds.width}:${bounds.height}`,
+    bounds
+  );
+}
+
 function rebuildState(state: StudioMapStreamState): void {
   const map = clone(state.manifest.renderData.map);
   const terrain = map.terrainRenderData;
@@ -561,16 +623,26 @@ function rebuildState(state: StudioMapStreamState): void {
   });
   if (terrain) {
     terrain.morphologyFeatures = [...features.values()];
-    terrain.version = `streamed:${state.manifest.revision}:${[
+    terrain.version = `streamed:${state.manifest.revision}:${state.generation}:${[
       ...state.chunks.keys(),
     ]
       .sort()
       .join(",")}`;
+    terrain.streamUpdate = {
+      revision: state.manifest.revision,
+      generation: state.generation,
+      dirtyRegions: [...state.pendingTerrainRegions.values()],
+      activeRegions: [...state.chunks.values()].map((chunk) =>
+        getChunkTerrainBounds(state, chunk)
+      ),
+    };
     if (terrain.terrainControl) {
       terrain.terrainControl.regions = [...controlRegions.values()];
     }
   }
   state.map = map;
+  state.pendingTerrainRegions.clear();
+  state.needsRebuild = false;
 }
 
 export function createStudioMapStreamState(
@@ -580,23 +652,42 @@ export function createStudioMapStreamState(
     manifest,
     chunks: new Map(),
     map: {},
+    generation: 0,
+    needsRebuild: false,
+    pendingTerrainRegions: new Map(),
   } as StudioMapStreamState;
   rebuildState(state);
   return state;
+}
+
+export function getStudioMapStreamData(
+  state: StudioMapStreamState
+): Record<string, any> {
+  if (state.needsRebuild) {
+    state.generation += 1;
+    rebuildState(state);
+  }
+  return state.map;
 }
 
 export function applyStudioMapStreamChunk(
   state: StudioMapStreamState,
   chunk: MapStreamChunk<StudioMapStreamChunkData>
 ): void {
+  const previous = state.chunks.get(chunk.key);
+  if (previous) markTerrainRegion(state, previous);
   state.chunks.set(chunk.key, chunk);
-  rebuildState(state);
+  markTerrainRegion(state, chunk);
+  state.needsRebuild = true;
 }
 
 export function removeStudioMapStreamChunk(
   state: StudioMapStreamState,
   key: string
 ): void {
+  const previous = state.chunks.get(key);
+  if (!previous) return;
+  markTerrainRegion(state, previous);
   state.chunks.delete(key);
-  rebuildState(state);
+  state.needsRebuild = true;
 }


### PR DESCRIPTION
## What changed

- consolidate all Studio stream deltas from one packet before rebuilding client map state
- publish dirty and active terrain regions with a monotonic stream generation
- invalidate only intersecting 768 px terrain renderer chunks
- preserve unaffected canvases, Pixi textures, sprites, and water overlays
- keep the existing full-map path for non-streamed Studio maps
- add a patch changeset for `@rpgjs/studio`

## Why

Each streamed chunk update changed the global terrain version. `StudioTerrainChunkRenderer.renderMap()` consequently recreated every terrain chunk synchronously, including terrain-control masks, morphology, and water overlays. A single movement-triggered stream update could block the browser main thread for hundreds of milliseconds.

The renderer now maps consolidated dirty regions to its own chunk grid and only rebuilds those entries. Removed regions destroy only renderer chunks no longer covered by retained stream data.

Closes #339.

## Validation

- `pnpm vitest run packages/studio` — 27 files, 190 tests passed
- `pnpm test --run` — 152 files, 1,113 tests passed, 19 skipped
- `pnpm test:types` — 3 files, 20 tests passed, no type errors
- `pnpm build` and `pnpm --filter @rpgjs/studio build`
- `pnpm api:boundary`
- `pnpm changeset status`
- packed `@rpgjs/studio`, installed it into the v5 starter, and completed a production build
- started the starter on `127.0.0.1:4179`, verified rendering and keyboard movement in Chromium, with no page errors or failed requests

Headless Chromium emitted only software-WebGL/GPU readback warnings; the rendered game and interaction were correct.
