### PR TITLE
fix: verify npm latest tags after release

### DIFF
--- a/.changeset/curly-npm-latest-verification.md
+++ b/.changeset/curly-npm-latest-verification.md
@@ -1,0 +1,4 @@
+---
+---
+
+Verify npm `latest` dist-tags after release, retry registry inconsistencies, and fail CI when a tag update does not persist.

--- a/bin/tag-latest.spec.ts
+++ b/bin/tag-latest.spec.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ensureLatestTag } from './tag-latest';
+
+function createNpmClient(latestVersions: Array<string | undefined>) {
+  const versions = [...latestVersions];
+  const getLatest = vi.fn(async () => versions.shift());
+  const addLatest = vi.fn(async () => undefined);
+
+  return {
+    client: { getLatest, addLatest },
+    getLatest,
+    addLatest,
+  };
+}
+
+describe('ensureLatestTag', () => {
+  it('skips npm writes when latest already matches', async () => {
+    const { client, addLatest } = createNpmClient(['5.0.0-beta.30']);
+
+    await ensureLatestTag('@rpgjs/studio', '5.0.0-beta.30', {
+      npmClient: client,
+    });
+
+    expect(addLatest).not.toHaveBeenCalled();
+  });
+
+  it('writes and verifies the latest tag', async () => {
+    const { client, addLatest } = createNpmClient([
+      '5.0.0-beta.29',
+      '5.0.0-beta.30',
+    ]);
+
+    await ensureLatestTag('@rpgjs/studio', '5.0.0-beta.30', {
+      npmClient: client,
+    });
+
+    expect(addLatest).toHaveBeenCalledOnce();
+    expect(addLatest).toHaveBeenCalledWith('@rpgjs/studio@5.0.0-beta.30');
+  });
+
+  it('retries when npm acknowledges a tag that is not visible', async () => {
+    const { client, addLatest } = createNpmClient([
+      '5.0.0-beta.29',
+      '5.0.0-beta.29',
+      '5.0.0-beta.29',
+      '5.0.0-beta.30',
+    ]);
+    const sleep = vi.fn(async () => undefined);
+
+    await ensureLatestTag('@rpgjs/studio', '5.0.0-beta.30', {
+      maxAttempts: 2,
+      retryDelayMs: 1,
+      npmClient: client,
+      sleep,
+    });
+
+    expect(addLatest).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledOnce();
+    expect(sleep).toHaveBeenCalledWith(1);
+  });
+
+  it('fails the release when the latest tag never converges', async () => {
+    const { client, addLatest } = createNpmClient([
+      '5.0.0-beta.29',
+      '5.0.0-beta.29',
+      '5.0.0-beta.29',
+      '5.0.0-beta.29',
+    ]);
+
+    await expect(
+      ensureLatestTag('@rpgjs/studio', '5.0.0-beta.30', {
+        maxAttempts: 2,
+        retryDelayMs: 0,
+        npmClient: client,
+        sleep: async () => undefined,
+      }),
+    ).rejects.toThrow(
+      'Failed to verify @rpgjs/studio@latest as 5.0.0-beta.30 after 2 attempts',
+    );
+
+    expect(addLatest).toHaveBeenCalledTimes(2);
+  });
+});

--- a/bin/tag-latest.ts
+++ b/bin/tag-latest.ts
@@ -2,6 +2,7 @@
 
 import { readdir, readFile } from 'fs/promises';
 import { join, resolve } from 'path';
+import { pathToFileURL } from 'url';
 import { execa } from 'execa';
 
 interface PackageJson {
@@ -13,7 +14,87 @@ interface PackageJson {
   };
 }
 
-async function main(): Promise<void> {
+interface NpmClient {
+  getLatest(packageName: string): Promise<string | undefined>;
+  addLatest(spec: string): Promise<void>;
+}
+
+interface EnsureLatestTagOptions {
+  maxAttempts?: number;
+  retryDelayMs?: number;
+  npmClient?: NpmClient;
+  sleep?: (delayMs: number) => Promise<void>;
+}
+
+const DEFAULT_MAX_ATTEMPTS = 6;
+const DEFAULT_RETRY_DELAY_MS = 10_000;
+
+const defaultNpmClient: NpmClient = {
+  async getLatest(packageName) {
+    const { stdout } = await execa(
+      'npm',
+      ['view', packageName, 'dist-tags.latest', '--json'],
+      { stdout: 'pipe' },
+    );
+
+    if (!stdout.trim()) return undefined;
+    return JSON.parse(stdout) as string;
+  },
+  async addLatest(spec) {
+    await execa('npm', ['dist-tag', 'add', spec, 'latest'], { stdio: 'inherit' });
+  },
+};
+
+const wait = (delayMs: number) =>
+  new Promise<void>(resolveTimeout => setTimeout(resolveTimeout, delayMs));
+
+export async function ensureLatestTag(
+  packageName: string,
+  version: string,
+  options: EnsureLatestTagOptions = {},
+): Promise<void> {
+  const maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const retryDelayMs = options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
+  const npmClient = options.npmClient ?? defaultNpmClient;
+  const sleep = options.sleep ?? wait;
+  const spec = `${packageName}@${version}`;
+
+  if (maxAttempts < 1) {
+    throw new Error('maxAttempts must be at least 1');
+  }
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const latest = await npmClient.getLatest(packageName);
+    if (latest === version) {
+      console.log(`Verified ${packageName}@latest is ${version}`);
+      return;
+    }
+
+    console.log(
+      `Tagging ${spec} as latest (attempt ${attempt}/${maxAttempts}, current: ${latest ?? 'unset'})`,
+    );
+    await npmClient.addLatest(spec);
+
+    const verifiedLatest = await npmClient.getLatest(packageName);
+    if (verifiedLatest === version) {
+      console.log(`Verified ${packageName}@latest is ${version}`);
+      return;
+    }
+
+    if (attempt < maxAttempts) {
+      console.warn(
+        `${packageName}@latest is still ${verifiedLatest ?? 'unset'}; retrying in ${retryDelayMs}ms`,
+      );
+      await sleep(retryDelayMs);
+    }
+  }
+
+  throw new Error(
+    `Failed to verify ${packageName}@latest as ${version} after ${maxAttempts} attempts`,
+  );
+}
+
+export async function main(): Promise<void> {
   const packagesDir = join(resolve(process.cwd()), 'packages');
   const entries = await readdir(packagesDir, { withFileTypes: true });
 
@@ -26,13 +107,13 @@ async function main(): Promise<void> {
     if (!packageJson.name || !packageJson.version || packageJson.private) continue;
     if (packageJson.name === '@rpgjs/physic') continue;
 
-    const spec = `${packageJson.name}@${packageJson.version}`;
-    console.log(`Tagging ${spec} as latest`);
-    await execa('npm', ['dist-tag', 'add', spec, 'latest'], { stdio: 'inherit' });
+    await ensureLatestTag(packageJson.name, packageJson.version);
   }
 }
 
-main().catch(error => {
-  console.error(error);
-  process.exit(1);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(error => {
+    console.error(error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- skip npm dist-tag writes when `latest` already matches
- verify every `latest` update and retry registry inconsistencies
- fail the release when npm acknowledges an update that never persists
- keep `@rpgjs/physic` excluded
- add regression tests and an empty tracking changeset

## Validation
- `pnpm vitest run bin/tag-latest.spec.ts`
- strict targeted TypeScript compilation for the script and tests
- `git diff --check`
- `pnpm changeset status`