### PR TITLE
fix(tiledmap): preserve z-order in MMORPG streams

### DIFF
--- a/.changeset/bright-tiled-z-order.md
+++ b/.changeset/bright-tiled-z-order.md
@@ -2,4 +2,4 @@
 "@rpgjs/tiledmap": patch
 ---
 
-Preserve Tiled tile and layer `z` metadata in MMORPG map streams so foreground tiles render above characters while other private custom properties remain server-side.
+Preserve Tiled tile and layer `z` metadata and their tile ID positions in MMORPG map streams so foreground tiles render above characters without assigning depth to the wrong tiles, while other private custom properties remain server-side.

--- a/.changeset/bright-tiled-z-order.md
+++ b/.changeset/bright-tiled-z-order.md
@@ -1,0 +1,5 @@
+---
+"@rpgjs/tiledmap": patch
+---
+
+Preserve Tiled tile and layer `z` metadata in MMORPG map streams so foreground tiles render above characters while other private custom properties remain server-side.

--- a/packages/tiledmap/src/streaming.spec.ts
+++ b/packages/tiledmap/src/streaming.spec.ts
@@ -35,7 +35,10 @@ describe("Tiled map streaming adapter", () => {
           name: "tiles",
           image: { source: "tiles.png", width: 64, height: 64 },
           wangsets: [{ name: "private-editor-metadata" }],
-          tiles: [{ id: 0, properties: { collision: true, z: 2 } }],
+          tiles: [
+            { id: 0, properties: { collision: true, z: 2 } },
+            { id: 2, properties: { collision: true, z: 0 } },
+          ],
         }],
       },
       hitboxes: [
@@ -52,6 +55,8 @@ describe("Tiled map streaming adapter", () => {
     expect(definition.manifest.renderData.map.tilesets[0].image.source).toBe("/assets/tiles.png");
     expect(definition.manifest.renderData.map.tilesets[0].tiles).toEqual([
       { id: 0, properties: { z: 2 } },
+      { id: 1 },
+      { id: 2, properties: { z: 0 } },
     ]);
     expect(definition.manifest.renderData.map.layers[0].properties).toEqual({ z: 1 });
     expect(definition.manifest.renderData.map.layers[1].objects).toEqual([]);

--- a/packages/tiledmap/src/streaming.spec.ts
+++ b/packages/tiledmap/src/streaming.spec.ts
@@ -18,7 +18,15 @@ describe("Tiled map streaming adapter", () => {
         objects: [{ name: "secret-event" }],
         properties: { serverSecret: true },
         layers: [
-          { id: 1, name: "ground", type: "tilelayer", width: 4, height: 2, data: [1, 2, 0, 0, 0, 0, 3, 4] },
+          {
+            id: 1,
+            name: "ground",
+            type: "tilelayer",
+            width: 4,
+            height: 2,
+            data: [1, 2, 0, 0, 0, 0, 3, 4],
+            properties: { z: 1, serverSecret: true },
+          },
           { id: 2, name: "events", type: "objectgroup", objects: [{ name: "secret-event" }] },
         ],
         tilesets: [{
@@ -27,7 +35,7 @@ describe("Tiled map streaming adapter", () => {
           name: "tiles",
           image: { source: "tiles.png", width: 64, height: 64 },
           wangsets: [{ name: "private-editor-metadata" }],
-          tiles: [{ id: 0, properties: { collision: true } }],
+          tiles: [{ id: 0, properties: { collision: true, z: 2 } }],
         }],
       },
       hitboxes: [
@@ -42,6 +50,10 @@ describe("Tiled map streaming adapter", () => {
     expect(definition.manifest.renderData.map.tilesets[0].source).toBeUndefined();
     expect(definition.manifest.renderData.map.tilesets[0].wangsets).toBeUndefined();
     expect(definition.manifest.renderData.map.tilesets[0].image.source).toBe("/assets/tiles.png");
+    expect(definition.manifest.renderData.map.tilesets[0].tiles).toEqual([
+      { id: 0, properties: { z: 2 } },
+    ]);
+    expect(definition.manifest.renderData.map.layers[0].properties).toEqual({ z: 1 });
     expect(definition.manifest.renderData.map.layers[1].objects).toEqual([]);
     expect(definition.chunks["0:0"].hitboxes.map((hitbox) => hitbox.id)).toEqual([
       "wall",

--- a/packages/tiledmap/src/streaming.ts
+++ b/packages/tiledmap/src/streaming.ts
@@ -48,7 +48,7 @@ function sanitizeTileset(tileset: any, basePath: string, usedGids: Set<number>):
   }
   if (Array.isArray(next.tiles)) {
     const firstgid = Number(next.firstgid) || 0;
-    next.tiles = next.tiles
+    const renderTiles = next.tiles
       .filter((tile: any) => usedGids.has(firstgid + Number(tile.id)))
       .map((tile: any) => {
         const sanitized = { ...tile };
@@ -65,6 +65,17 @@ function sanitizeTileset(tileset: any, basePath: string, usedGids: Set<number>):
         || !!tile.image
         || !!tile.properties
       ));
+    const highestTileId = renderTiles.reduce(
+      (highest: number, tile: any) => Math.max(highest, Number(tile.id)),
+      -1,
+    );
+    const renderTilesById = new Map<number, any>(
+      renderTiles.map((tile: any) => [Number(tile.id), tile]),
+    );
+    next.tiles = Array.from(
+      { length: highestTileId + 1 },
+      (_, id) => renderTilesById.get(id) ?? { id },
+    );
   }
   return next;
 }

--- a/packages/tiledmap/src/streaming.ts
+++ b/packages/tiledmap/src/streaming.ts
@@ -33,6 +33,10 @@ function joinPublicPath(basePath: string, source: string): string {
   return `${basePath.replace(/\/$/, "")}/${source.replace(/^\.\//, "")}`;
 }
 
+function sanitizeRenderProperties(properties: any): { z: number } | undefined {
+  return Number.isFinite(properties?.z) ? { z: properties.z } : undefined;
+}
+
 function sanitizeTileset(tileset: any, basePath: string, usedGids: Set<number>): any {
   const next = clone(tileset);
   delete next.source;
@@ -49,19 +53,26 @@ function sanitizeTileset(tileset: any, basePath: string, usedGids: Set<number>):
       .map((tile: any) => {
         const sanitized = { ...tile };
         delete sanitized.objectgroup;
-        delete sanitized.properties;
+        sanitized.properties = sanitizeRenderProperties(tile.properties);
+        if (!sanitized.properties) delete sanitized.properties;
         delete sanitized.class;
         delete sanitized.type;
         return sanitized;
       })
-      .filter((tile: any) => Array.isArray(tile.animation) || Array.isArray(tile.animations) || !!tile.image);
+      .filter((tile: any) => (
+        Array.isArray(tile.animation)
+        || Array.isArray(tile.animations)
+        || !!tile.image
+        || !!tile.properties
+      ));
   }
   return next;
 }
 
 function sanitizeLayerTemplate(layer: any): any | undefined {
   const next = clone(layer);
-  delete next.properties;
+  next.properties = sanitizeRenderProperties(layer.properties);
+  if (!next.properties) delete next.properties;
   delete next.class;
   if (layer?.type === "objectgroup") {
     // Preserve the layer slot/order used by CanvasEngine to mount RPGJS


### PR DESCRIPTION
Closes #356

## Summary
- preserve numeric `z` rendering metadata for streamed Tiled tiles and layers
- keep all other custom Tiled properties server-side
- retain tiles whose only client-visible metadata is their `z` value
- preserve tile ID positions so depth metadata is not assigned to another tile
- add a regression test with non-consecutive tile IDs
- add a patch changeset for `@rpgjs/tiledmap`

## Regression fixed during review
The first implementation compacted the sanitized tileset array. CanvasEngine reads tile metadata by local tile ID, so compacting the array could transfer a foreground `z` value to the ground tile and hide the player and decorations. Empty public placeholders now retain the original indices without exposing private properties.

## Verification
- `pnpm exec vitest run packages/tiledmap` (11 tests passed)
- `pnpm --dir packages/tiledmap build`
- packed the local `@rpgjs/tiledmap` package and installed it in the v5 starter
- started the starter in MMORPG mode and verified in the browser that terrain, trees, player and NPC render together after progressive loading