### PR TITLE
fix(client): keep MMORPG mobile joystick responsive

### DIFF
--- a/.changeset/fresh-mobile-controls.md
+++ b/.changeset/fresh-mobile-controls.md
@@ -2,4 +2,4 @@
 "@rpgjs/client": patch
 ---
 
-Keep the mobile joystick connected when the current MMORPG player component is remounted.
+Keep the mobile joystick connected across MMORPG streamed map updates by preventing retired character effects from overwriting live controls, continue repeating held movement without new pointer events, and preserve joystick power after direction changes.

--- a/.changeset/fresh-mobile-controls.md
+++ b/.changeset/fresh-mobile-controls.md
@@ -1,0 +1,5 @@
+---
+"@rpgjs/client": patch
+---
+
+Keep the mobile joystick connected when the current MMORPG player component is remounted.

--- a/.changeset/fresh-mobile-controls.md
+++ b/.changeset/fresh-mobile-controls.md
@@ -3,3 +3,5 @@
 ---
 
 Keep the mobile joystick connected across MMORPG streamed map updates by preventing retired character effects from overwriting live controls, continue repeating held movement without new pointer events, and preserve joystick power after direction changes.
+
+Dispose the character controls effect through its underlying subscription so streamed player removal completes without a runtime error.

--- a/docs/api/client/rpg-client-engine.md
+++ b/docs/api/client/rpg-client-engine.md
@@ -1013,49 +1013,37 @@ engine.setCameraFollow(null);
 
 ## setKeyboardControls
 
-Assigns a CanvasEngine KeyboardControls instance to the dependency injection context
+Registers the current player's live CanvasEngine controls on the client.
 
-This method registers a KeyboardControls instance from CanvasEngine into the DI container,
-making it available for injection throughout the application. The particularity is that
-this method is automatically called when a sprite is displayed on the map, allowing the
-controls to be automatically associated with the active sprite.
-
-## Design
-
-- The instance is stored in the DI context under the `KeyboardControls` token
-- It's automatically assigned when a sprite component mounts (in `character.ce`)
-- The controls instance comes from the CanvasEngine component's directives
-- Once registered, it can be retrieved using `inject(KeyboardControls)` from anywhere
+Used automatically when the player component mounts in standalone RPG and
+MMORPG modes. Destroyed directives are ignored so a retiring component cannot
+overwrite replacement controls during streamed map updates. Input handling
+remains client-side; this does not change server movement authority.
 
 - Source: `packages/client/src/RpgClientEngine.ts`
 - Kind: `method`
+- Member of: `RpgClientEngine`
 - Defined in: `RpgClientEngine`
 
 ### Signature
 
 ```ts
-setKeyboardControls(controlInstance: any)
+setKeyboardControls
 ```
 
 ### Parameters
 
-- `controlInstance`: `any`
+- `controlInstance`: `ControlsDirective`
+
+### Returns
+
+Nothing.
 
 ### Examples
 
 ```ts
-// The method is automatically called when a sprite is displayed:
-// client.setKeyboardControls(element.directives.controls)
-
-// Later, retrieve and use the controls instance:
-import { Input, inject, KeyboardControls } from '@rpgjs/client'
-
-const controls = inject(KeyboardControls)
-const control = controls.getControl(Input.Enter)
-
-if (control) {
-  console.log(control.actionName) // 'action'
-}
+// Inside the current player's CanvasEngine mount callback:
+client.setKeyboardControls(element.directives.controls)
 ```
 
 ## setSoundResolver

--- a/docs/gui/mobile.md
+++ b/docs/gui/mobile.md
@@ -110,3 +110,9 @@ they do not create gameplay authority on the client.
 The virtual joystick uses CanvasEngine's `Joystick` component for input. RPGJS
 movement is cardinal, so diagonal joystick positions are resolved to the nearest
 single RPGJS movement control before being repeated.
+
+Holding the joystick continues movement without requiring further pointer movement.
+Changing direction preserves the current joystick power. Releasing the joystick or
+returning it below the configured threshold stops repetition. In MMORPG mode, the
+overlay follows replacement current-player controls so a player remount does not
+require releasing and pressing the joystick again.

--- a/packages/client/src/RpgClientEngine.controls.spec.ts
+++ b/packages/client/src/RpgClientEngine.controls.spec.ts
@@ -1,21 +1,41 @@
-import { signal } from "canvasengine";
+import { ControlsDirective, signal, type Element } from "canvasengine";
 import { describe, expect, it, vi } from "vitest";
 import { RpgClientEngine } from "./RpgClientEngine";
 
+function createControls() {
+  const element = {
+    props: { controls: { down: { bind: "down", keyDown: vi.fn() } } },
+    propObservables: {},
+  } as unknown as Element;
+  const controls = new ControlsDirective();
+  controls.onInit(element);
+  return { controls, destroy: () => controls.onDestroy(element) };
+}
+
 describe("RpgClientEngine controls", () => {
-  it("publishes replacement controls when the current player is remounted", () => {
+  it("does not let a retired character overwrite replacement controls", () => {
     const engine = Object.create(RpgClientEngine.prototype) as RpgClientEngine;
     engine.context = { values: {} } as any;
-    engine.controlsReady = { set: vi.fn() } as any;
-    engine.activeKeyboardControls = signal<any>(null);
-    const firstControls = { applyControl: vi.fn() };
-    const replacementControls = { applyControl: vi.fn() };
+    engine.controlsReady = signal<boolean | undefined>(undefined);
+    engine.activeKeyboardControls = signal<ControlsDirective | null>(null);
+    const first = createControls();
+    const replacement = createControls();
 
-    engine.setKeyboardControls(firstControls);
-    engine.setKeyboardControls(replacementControls);
+    try {
+      engine.setKeyboardControls(first.controls);
+      first.destroy();
+      engine.setKeyboardControls(replacement.controls);
 
-    expect(engine.activeKeyboardControls()).toBe(replacementControls);
-    expect(engine.context.values["inject:KeyboardControls"].values.get("__default__"))
-      .toBe(replacementControls);
+      // A retiring character effect can run again while streamed layers change.
+      engine.setKeyboardControls(first.controls);
+
+      expect(engine.activeKeyboardControls()).toBe(replacement.controls);
+      expect(engine.context.values["inject:KeyboardControls"].values.get("__default__"))
+        .toBe(replacement.controls);
+      expect(engine.controlsReady()).toBe(true);
+    } finally {
+      first.destroy();
+      replacement.destroy();
+    }
   });
 });

--- a/packages/client/src/RpgClientEngine.controls.spec.ts
+++ b/packages/client/src/RpgClientEngine.controls.spec.ts
@@ -1,0 +1,21 @@
+import { signal } from "canvasengine";
+import { describe, expect, it, vi } from "vitest";
+import { RpgClientEngine } from "./RpgClientEngine";
+
+describe("RpgClientEngine controls", () => {
+  it("publishes replacement controls when the current player is remounted", () => {
+    const engine = Object.create(RpgClientEngine.prototype) as RpgClientEngine;
+    engine.context = { values: {} } as any;
+    engine.controlsReady = { set: vi.fn() } as any;
+    engine.activeKeyboardControls = signal<any>(null);
+    const firstControls = { applyControl: vi.fn() };
+    const replacementControls = { applyControl: vi.fn() };
+
+    engine.setKeyboardControls(firstControls);
+    engine.setKeyboardControls(replacementControls);
+
+    expect(engine.activeKeyboardControls()).toBe(replacementControls);
+    expect(engine.context.values["inject:KeyboardControls"].values.get("__default__"))
+      .toBe(replacementControls);
+  });
+});

--- a/packages/client/src/RpgClientEngine.ts
+++ b/packages/client/src/RpgClientEngine.ts
@@ -1,7 +1,7 @@
 import Canvas from "./components/scenes/canvas.ce";
 import BuiltinSceneMap from "./components/scenes/draw-map.ce";
 import { inject } from './core/inject'
-import { signal, bootstrapCanvas, Howl, Howler, trigger, type Trigger } from "canvasengine";
+import { signal, bootstrapCanvas, Howl, Howler, trigger, type Trigger, type ControlsDirective } from "canvasengine";
 import { AbstractWebsocket, WebSocketToken } from "./services/AbstractSocket";
 import { LoadMapService, LoadMapToken } from "./services/loadMap";
 import { RpgSound } from "./Sound";
@@ -258,7 +258,8 @@ export class RpgClientEngine<T = any> {
   mapShakeTrigger: ConfigurableTrigger<MapShakeOptions> = trigger<MapShakeOptions>();
 
   controlsReady = signal<boolean | undefined>(undefined); 
-  activeKeyboardControls = signal<any>(null);
+  // Active client input directive, shared with the mobile overlay.
+  activeKeyboardControls = signal<ControlsDirective | null>(null);
   gamePause = signal(false);
   /**
    * Freezes map rendering for short presentation-only beats such as combat
@@ -410,39 +411,28 @@ export class RpgClientEngine<T = any> {
   }
 
   /**
-   * Assigns a CanvasEngine KeyboardControls instance to the dependency injection context
-   * 
-   * This method registers a KeyboardControls instance from CanvasEngine into the DI container,
-   * making it available for injection throughout the application. The particularity is that
-   * this method is automatically called when a sprite is displayed on the map, allowing the
-   * controls to be automatically associated with the active sprite.
-   * 
-   * ## Design
-   * 
-   * - The instance is stored in the DI context under the `KeyboardControls` token
-   * - It's automatically assigned when a sprite component mounts (in `character.ce`)
-   * - The controls instance comes from the CanvasEngine component's directives
-   * - Once registered, it can be retrieved using `inject(KeyboardControls)` from anywhere
-   * 
-   * @param controlInstance - The CanvasEngine KeyboardControls instance to register
-   * 
+   * Registers the current player's live CanvasEngine controls on the client.
+   *
+   * Used automatically when the player component mounts in standalone RPG and
+   * MMORPG modes. Destroyed directives are ignored so a retiring component cannot
+   * overwrite replacement controls during streamed map updates. Input handling
+   * remains client-side; this does not change server movement authority.
+   *
+   * @title setKeyboardControls
+   * @method setKeyboardControls
+   * @param controlInstance - The live CanvasEngine controls directive to register.
+   * @returns Nothing.
+   * @memberof RpgClientEngine
    * @example
    * ```ts
-   * // The method is automatically called when a sprite is displayed:
-   * // client.setKeyboardControls(element.directives.controls)
-   * 
-   * // Later, retrieve and use the controls instance:
-   * import { Input, inject, KeyboardControls } from '@rpgjs/client'
-   * 
-   * const controls = inject(KeyboardControls)
-   * const control = controls.getControl(Input.Enter)
-   * 
-   * if (control) {
-   *   console.log(control.actionName) // 'action'
-   * }
+   * // Inside the current player's CanvasEngine mount callback:
+   * client.setKeyboardControls(element.directives.controls)
    * ```
    */
-  setKeyboardControls(controlInstance: any) {
+  setKeyboardControls(controlInstance: ControlsDirective): void {
+    // CanvasEngine clears the keyboard when a controls directive is destroyed.
+    // A retiring character's effect must not replace the new player's controls.
+    if (!controlInstance?.keyboard) return;
     const currentValues = this.context.values['inject:' + 'KeyboardControls']
     this.context.values['inject:' + 'KeyboardControls'] = {
       ...currentValues,

--- a/packages/client/src/RpgClientEngine.ts
+++ b/packages/client/src/RpgClientEngine.ts
@@ -258,6 +258,7 @@ export class RpgClientEngine<T = any> {
   mapShakeTrigger: ConfigurableTrigger<MapShakeOptions> = trigger<MapShakeOptions>();
 
   controlsReady = signal<boolean | undefined>(undefined); 
+  activeKeyboardControls = signal<any>(null);
   gamePause = signal(false);
   /**
    * Freezes map rendering for short presentation-only beats such as combat
@@ -447,6 +448,7 @@ export class RpgClientEngine<T = any> {
       ...currentValues,
       values: new Map([['__default__', controlInstance]])
     }
+    this.activeKeyboardControls.set(controlInstance);
     this.controlsReady.set(true);
   }
 

--- a/packages/client/src/components/character.ce
+++ b/packages/client/src/components/character.ce
@@ -70,6 +70,8 @@
 <script>
   import { signal, effect, mount, computed, tick, animatedSignal, on, untracked } from "canvasengine";
   import { Assets } from "pixi.js";
+  import { observeCurrentPlayerControls } from "./current-player-controls";
+  import type { Subscription } from "rxjs";
 
   import { lastValueFrom, combineLatest, pairwise, filter, map, startWith } from "rxjs";
   import { Particle } from "@canvasengine/presets";
@@ -1297,7 +1299,7 @@
     });
   };
 
-  let controlsSubscription = null;
+  let controlsSubscription: Subscription | null = null;
   const onBeforeDestroy = async () => {
     // Stop publishing controls before asynchronous removal hooks can yield.
     controlsSubscription?.unsubscribe();
@@ -1339,11 +1341,11 @@
     }
     hooks.callHooks("client-sprite-onAdd", sprite).subscribe()
     hooks.callHooks("client-sceneMap-onAddSprite", client.sceneMap, sprite).subscribe()
-    controlsSubscription = effect(() => {
-      if (isCurrentPlayer()) {
-        client.setKeyboardControls(element.directives.controls)
-      }
-    })
+    controlsSubscription = observeCurrentPlayerControls(
+      isCurrentPlayer,
+      element.directives.controls,
+      (controls) => client.setKeyboardControls(controls)
+    );
 
     effect(() => {
       const followRevision = client.cameraFollowRevision();

--- a/packages/client/src/components/character.ce
+++ b/packages/client/src/components/character.ce
@@ -1297,7 +1297,11 @@
     });
   };
 
+  let controlsSubscription = null;
   const onBeforeDestroy = async () => {
+    // Stop publishing controls before asynchronous removal hooks can yield.
+    controlsSubscription?.unsubscribe();
+    controlsSubscription = null;
     await runBeforeRemove();
     await waitForTemporaryAnimationEnd();
     if (typeof document !== 'undefined') {
@@ -1335,7 +1339,7 @@
     }
     hooks.callHooks("client-sprite-onAdd", sprite).subscribe()
     hooks.callHooks("client-sceneMap-onAddSprite", client.sceneMap, sprite).subscribe()
-    effect(() => {
+    controlsSubscription = effect(() => {
       if (isCurrentPlayer()) {
         client.setKeyboardControls(element.directives.controls)
       }
@@ -1378,6 +1382,7 @@
     })
 
     return () => {
+      controlsSubscription?.unsubscribe();
       if (ownsCameraFollowRevision(appliedCameraFollowRevision, client.cameraFollowRevision())) {
         clearCameraFollowPlugins(element.props.context?.viewport, appliedCameraFollowOwnership);
       }

--- a/packages/client/src/components/current-player-controls.spec.ts
+++ b/packages/client/src/components/current-player-controls.spec.ts
@@ -1,0 +1,25 @@
+import { signal, type ControlsDirective } from "canvasengine";
+import { describe, expect, it, vi } from "vitest";
+import { observeCurrentPlayerControls } from "./current-player-controls";
+
+describe("current player controls effect lifetime", () => {
+  it("stops publishing synchronously before asynchronous character removal", () => {
+    const currentPlayer = signal(false);
+    const controls = {} as ControlsDirective;
+    const register = vi.fn();
+    const subscription = observeCurrentPlayerControls(currentPlayer, controls, register);
+
+    expect(register).not.toHaveBeenCalled();
+    currentPlayer.set(true);
+    expect(register).toHaveBeenCalledExactlyOnceWith(controls);
+
+    // Called at the start of onBeforeDestroy, before removal hooks can yield.
+    expect(() => subscription.unsubscribe()).not.toThrow();
+    expect(subscription.closed).toBe(true);
+    currentPlayer.set(false);
+    currentPlayer.set(true);
+    expect(register).toHaveBeenCalledOnce();
+    // The later mount cleanup may dispose the same subscription again.
+    expect(() => subscription.unsubscribe()).not.toThrow();
+  });
+});

--- a/packages/client/src/components/current-player-controls.ts
+++ b/packages/client/src/components/current-player-controls.ts
@@ -1,0 +1,14 @@
+import { effect, type ControlsDirective } from "canvasengine";
+import type { Subscription } from "rxjs";
+
+// Mount callbacks run outside CanvasEngine's automatic subscription tracking.
+// Return the effect's actual RxJS subscription for synchronous teardown.
+export function observeCurrentPlayerControls(
+  isCurrentPlayer: () => boolean,
+  controls: ControlsDirective,
+  register: (controls: ControlsDirective) => void,
+): Subscription {
+  return effect(() => {
+    if (isCurrentPlayer()) register(controls);
+  }).subscription;
+}

--- a/packages/client/src/components/gui/mobile/mobile.ce
+++ b/packages/client/src/components/gui/mobile/mobile.ce
@@ -36,11 +36,13 @@
 </Container>
 
 <script>
-    import { Button, Joystick, signal, mount, computed } from 'canvasengine'
+    import { Button, Joystick, effect, computed } from 'canvasengine'
     import { inject } from '../../../core/inject'
+    import { RpgClientEngine } from '../../../RpgClientEngine'
 
     const { data } = defineProps()
-    const controlsInstance = signal(null)
+    const engine = inject(RpgClientEngine)
+    const controlsInstance = engine.activeKeyboardControls
     const options = computed(() => data?.() || {})
     const layout = computed(() => options().layout || {})
     const components = computed(() => options().components || {})
@@ -382,9 +384,7 @@
         releaseJoystickControl()
     }
 
-    mount((element) => {
-        const control = inject('KeyboardControls')
-        controlsInstance.set(control)
-        applyJoystickOptions(control)
+    effect(() => {
+        applyJoystickOptions(controlsInstance())
     })
 </script>

--- a/packages/client/src/components/gui/mobile/mobile.ce
+++ b/packages/client/src/components/gui/mobile/mobile.ce
@@ -330,13 +330,14 @@
             releaseJoystickControl()
             return
         }
-        activeJoystickPower = power
         if (activeJoystickControl === controlName) {
+            activeJoystickPower = power
             startJoystickRepeat()
             return
         }
         releaseJoystickControl()
         activeJoystickControl = controlName
+        activeJoystickPower = power
         applyJoystickControl(controlName, true, power)
         startJoystickRepeat()
     }

--- a/packages/client/src/components/gui/mobile/mobile.spec.ts
+++ b/packages/client/src/components/gui/mobile/mobile.spec.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Container, h, signal, JoystickControls } from 'canvasengine';
+import { TestBed } from 'canvasengine/testing';
+import Mobile from './mobile.ce';
+
+const state = vi.hoisted(() => ({ engine: null as any }));
+vi.mock('../../../core/inject', () => ({ inject: () => state.engine }));
+
+let root: any;
+afterEach(() => {
+  root?.destroy();
+  vi.useRealTimers();
+});
+
+async function setup() {
+  document.body.innerHTML = '<div id="root"></div>';
+  const controls = new JoystickControls();
+  const move = vi.fn();
+  const release = vi.fn();
+  controls.setInputs({
+    down: { bind: 'down', repeat: true, keyDown: move, keyUp: release },
+    right: { bind: 'right', repeat: true, keyDown: move, keyUp: release },
+  });
+  state.engine = { activeKeyboardControls: signal({ joystick: controls }) };
+  let joystick: any;
+  root = await TestBed.createComponent(Mobile, { data: signal({
+    components: { joystick: (props: any) => { joystick = props; return h(Container); } },
+    buttons: { action: false, back: false },
+  }) });
+  await vi.waitFor(() => expect(joystick).toBeDefined());
+  vi.useFakeTimers();
+  return { controls, move, release, joystick };
+}
+
+describe('held mobile joystick', () => {
+  it('continues moving for 30 seconds without new pointer changes', async () => {
+    const { move, release, joystick } = await setup();
+    joystick.onChange({ direction: 'bottom', power: 0.8, angle: 270 });
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(move).toHaveBeenCalledTimes(601);
+    expect(move.mock.calls.every(([, payload]) => payload.power === 0.8)).toBe(true);
+    joystick.onEnd();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(move).toHaveBeenCalledTimes(601);
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it('preserves power when changing direction and then holding still', async () => {
+    const { move, joystick } = await setup();
+    joystick.onChange({ direction: 'bottom', power: 0.8, angle: 270 });
+    await vi.advanceTimersByTimeAsync(3_000);
+    joystick.onChange({ direction: 'right', power: 0.6, angle: 0 });
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(move.mock.lastCall?.[1]).toEqual({ power: 0.6 });
+  });
+
+  it('stops repeating when the joystick returns to its dead zone', async () => {
+    const { move, release, joystick } = await setup();
+    joystick.onChange({ direction: 'bottom', power: 0.8, angle: 270 });
+    await vi.advanceTimersByTimeAsync(3_000);
+    joystick.onChange({ direction: 'bottom', power: 0.05, angle: 270 });
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(move).toHaveBeenCalledTimes(61);
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it('keeps repeating on replacement controls without another pointer change', async () => {
+    const { controls, move, joystick } = await setup();
+    joystick.onChange({ direction: 'bottom', power: 0.8, angle: 270 });
+    await vi.advanceTimersByTimeAsync(3_000);
+    controls.destroy();
+    const replacement = new JoystickControls();
+    const replacementMove = vi.fn();
+    replacement.setInputs({ down: { bind: 'down', repeat: true, keyDown: replacementMove } });
+    state.engine.activeKeyboardControls.set({ joystick: replacement });
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(move).toHaveBeenCalledTimes(61);
+    expect(replacementMove).toHaveBeenCalledTimes(600);
+    expect(replacementMove.mock.lastCall?.[1]).toEqual({ power: 0.8 });
+    joystick.onEnd();
+    replacement.destroy();
+  });
+});

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     canvasengine(),
     dts({ 
       include: ['src/**/*.ts'],
+      exclude: ['src/**/*.spec.ts'],
       outDirs: 'dist',
       afterDiagnostic(diagnostics) {
         if (diagnostics.length > 0) throw new Error(`Declaration generation failed with ${diagnostics.length} TypeScript diagnostic(s)`)


### PR DESCRIPTION
## Problem

Holding the mobile joystick in MMORPG mode stops moving the player after a streamed map update. A replacement player publishes fresh controls, but an effect belonging to the retired character can run again and overwrite them with an already destroyed directive. Joystick events still fire, but no movement callback remains connected.

## Fix

- share the active player controls with the mobile overlay
- unsubscribe the character's controls effect via `effect(...).subscription` before asynchronous destruction hooks; verify synchronous and repeated disposal
- reject destroyed directives when registering current-player controls
- preserve joystick power when changing direction and then holding still
- add component tests for a 30-second hold, release, dead zone, direction changes, and replacement controls, plus a regression using real CanvasEngine directive destruction
- update the client changeset, mobile guide, and generated API documentation
- exclude test sources from distributed client declarations

## Validation

- Client suite: 37 files, 174 tests passed; focused regression suite: 6 tests passed.
- Public API boundary and type contracts: passed (27 tests, no type errors).
- All 12 packages built; client rebuilt after the final lifecycle changes.
- Full suite: 190 files passed, 1 failed; 1,387 tests passed, 16 skipped. The sole failure is the server metrics test expecting `metrics.tick > 0`. It also fails at the original PR commit `1fb80403`, without these changes.
- Installed a packed local client into the `rpgjs/starter` v5 branch and built both MMORPG and RPG modes. Browser validation in MMORPG reproduced the stale-control overwrite and then verified continuous held input across streamed layer replacements: the player crossed y=512 to y=608 and could reverse direction without releasing. Release stops movement. Standalone production preview also renders and responds to the joystick without JavaScript errors; the only failed resource is the starter favicon (404). Validation uses the repository CanvasEngine versions (canvasengine 2.1.1 / presets 2.1.0), with a pnpm override ensuring transitive consumers use the packed client.
- npm `latest` and `beta` both remain `5.0.0-beta.33`; the client patch changeset is retained for the next beta release through CI.

Latest browser verification exercised multiple controls destructions with no JavaScript errors or unhandled promise rejections.

Fixes #357
