### PR TITLE
fix(server): restore player onMove and onDisconnected hooks

### DIFF
--- a/.changeset/calm-player-hooks.md
+++ b/.changeset/calm-player-hooks.md
@@ -1,0 +1,6 @@
+---
+"@rpgjs/common": patch
+"@rpgjs/server": patch
+---
+
+Restore the player `onMove` and `onDisconnected` lifecycle hooks.

--- a/packages/common/src/rooms/Map.ts
+++ b/packages/common/src/rooms/Map.ts
@@ -1688,6 +1688,14 @@ export abstract class RpgCommonMap<T extends RpgCommonPlayer> {
         }
       });
       if (changed) {
+        if (
+          typeof currentOwner.execMethod === "function" &&
+          !(typeof currentOwner.isEvent === "function" && currentOwner.isEvent())
+        ) {
+          void Promise.resolve(currentOwner.execMethod("onMove")).catch((error) => {
+            console.error("[RPGJS] Error during player onMove hooks:", error);
+          });
+        }
         const applyFrames = currentOwner.applyFrames;
         if (typeof applyFrames === "function") {
           queueMicrotask(() => applyFrames.call(currentOwner));

--- a/packages/server/src/rooms/lobby.ts
+++ b/packages/server/src/rooms/lobby.ts
@@ -35,6 +35,10 @@ export class LobbyRoom extends BaseRoom {
     (this as any).$applySync?.();
   }
 
+  async onLeave(player: RpgPlayer, _conn: RpgRoomConnection) {
+    await lastValueFrom(this.hooks.callHooks("server-player-onDisconnected", player));
+  }
+
   @Action('gui.interaction')
   async guiInteraction(player: RpgPlayer, value: { guiId: string, name: string, data: any }) {
     const gui = player.getGui(value.guiId);

--- a/packages/server/tests/lobby.spec.ts
+++ b/packages/server/tests/lobby.spec.ts
@@ -66,6 +66,30 @@ describe("LobbyRoom", () => {
     expect(hooks.callHooks).toHaveBeenCalledWith("server-player-onStart", player);
   });
 
+  test("client connection close runs onDisconnected", async () => {
+    const onDisconnected = vi.fn();
+    const serverModule = defineModule<RpgServer>({
+      player: { onDisconnected },
+    });
+    const serverClass = createServer({
+      providers: [provideServerModules([serverModule])],
+    });
+    const room = new ServerIo("lobby-1", { env: { TEST: "true" } });
+    const server = new serverClass(room);
+    await server.onStart();
+    await server.subRoom.onStart();
+    const client = new ClientIo(server, "player-client-id");
+    const request = new Request("http://localhost", {
+      method: "GET",
+      headers: { "Content-Type": "application/json" },
+    });
+    await server.onConnect(client.conn as any, { request } as any);
+    room.clients.set(client.id, client);
+
+    client.conn.close();
+    await vi.waitFor(() => expect(onDisconnected).toHaveBeenCalledOnce());
+  });
+
   test("client title screen interaction reaches lobby and runs onStart", async () => {
     let onStartCalls = 0;
     const serverModule = defineModule<RpgServer>({

--- a/packages/server/tests/move.spec.ts
+++ b/packages/server/tests/move.spec.ts
@@ -4,6 +4,8 @@ import { defineModule, createModule, Direction } from "@rpgjs/common";
 import { RpgPlayer, RpgServer, Move } from "../src";
 import { RpgClient } from "../../client/src";
 
+let onMoveCalls = 0;
+
 // Define server module with test map
 const serverModule = defineModule<RpgServer>({
   maps: [
@@ -15,6 +17,9 @@ const serverModule = defineModule<RpgServer>({
   player: {
     async onConnected(player) {
       await player.changeMap("test-map", { x: 100, y: 100 });
+    },
+    onMove() {
+      onMoveCalls += 1;
     },
   },
 });
@@ -29,6 +34,7 @@ let client: any;
 let fixture: TestingFixture;
 
 beforeEach(async () => {
+  onMoveCalls = 0;
   const myModule = createModule("TestModule", [
     {
       server: serverModule,
@@ -48,6 +54,12 @@ afterEach(async () => {
 
 
 describe("Move Routes - Basic Movements", () => {
+  test("calls the player onMove hook when its position changes", async () => {
+    await fixture.waitUntil(player.moveRoutes([Direction.Right]));
+
+    expect(onMoveCalls).toBeGreaterThan(0);
+  });
+
   test("should create player physics body with rectangular RPG hitbox and speed", async () => {
     const map = player.getCurrentMap() as any;
     const entity = map.getBody(player.id);

--- a/packages/server/tests/prediction-reconciliation.spec.ts
+++ b/packages/server/tests/prediction-reconciliation.spec.ts
@@ -29,6 +29,8 @@ function createStreamingDefinition(): MapStreamDefinition {
   };
 }
 
+let onMoveCalls = 0;
+
 const serverModule = defineModule<RpgServer>({
   maps: [
     {
@@ -40,6 +42,9 @@ const serverModule = defineModule<RpgServer>({
     async onConnected(player) {
       await player.changeMap("test-map", { x: 100, y: 100 });
     },
+    onMove() {
+      onMoveCalls += 1;
+    },
   },
 });
 
@@ -49,6 +54,7 @@ let player: RpgPlayer;
 let serverMap: any;
 
 beforeEach(async () => {
+  onMoveCalls = 0;
   const module = createModule("PredictionServerModule", [
     {
       server: serverModule,
@@ -65,6 +71,18 @@ afterEach(async () => {
 });
 
 describe("Prediction + Reconciliation Server Protocol", () => {
+  test("should call onMove after authoritative movement input changes position", async () => {
+    await serverMap.onInput(player, {
+      input: Direction.Right,
+      frame: 1,
+      tick: 0,
+      timestamp: Date.now(),
+    });
+    await serverMap.nextTickAsync();
+
+    expect(onMoveCalls).toBeGreaterThan(0);
+  });
+
   test("should reply pong with server tick", () => {
     const emitSpy = vi.spyOn(player, "emit");
     const payload = {


### PR DESCRIPTION
## Problem

Both hooks remained part of `RpgPlayerHooks`, but their v5 runtime dispatch paths were missing:

- closing the main lobby connection only invoked room cleanup because `LobbyRoom` had no `onLeave` implementation; map cleanup still dispatched `onLeaveMap`, but nothing dispatched `onDisconnected`
- authoritative physics position changes synchronized `x` and `y` and applied frames, but never dispatched `player.execMethod("onMove")`

## Reproduction

Regression tests first reproduced both failures on an unmodified `v5` checkout:

- closing a mock physical lobby connection left `onDisconnected` at 0 calls
- both a server movement route and an MMORPG-style authoritative input changed the player position while `onMove` remained at 0 calls

## Fix

- dispatch `server-player-onDisconnected` from the lobby room leave lifecycle
- dispatch `onMove` after authoritative player position synchronization (excluding events and client-only objects)
- cover physical disconnection, server movement routes, and network movement inputs
- add patch changesets for `@rpgjs/common` and `@rpgjs/server`

## Validation

- targeted lifecycle tests: 67 passed
- full suite: 189 files passed; 1,386 tests passed; 16 skipped
- type tests: 4 files and 27 tests passed, no type errors
- full build: all 12 packages built successfully
- `rpgjs/starter` v5: local common/server packages packed and installed; production build succeeded; game rendered and accepted keyboard movement with no browser console errors

The starter currently has a pre-existing stale lockfile and Vite native-config import warnings; neither is caused by this patch.

Fixes #358