### PR TITLE
fix(studio): deduplicate game data provider requests

### DIFF
--- a/.changeset/calm-studio-data-cache.md
+++ b/.changeset/calm-studio-data-cache.md
@@ -1,0 +1,5 @@
+---
+"@rpgjs/studio": patch
+---
+
+Deduplicate Studio project, map, database, and media reads within each runtime provider. Cache in-flight and resolved requests by resource identifier, keep project and map lookup keys distinct, and evict failed requests so later calls can retry.

--- a/packages/studio/src/data-provider/provider-factory.ts
+++ b/packages/studio/src/data-provider/provider-factory.ts
@@ -77,38 +77,53 @@ class AutoFallbackGameDataProvider implements GameDataProvider {
 
 class CachedGameDataProvider implements GameDataProvider {
   readonly kind: GameDataProvider['kind'];
+  private projectByKey = new Map<string, Promise<any>>();
+  private mapById = new Map<string, Promise<any>>();
   private mediaById = new Map<string, Promise<any>>();
+  private databaseByProjectId = new Map<string, Promise<any[]>>();
 
   constructor(private readonly source: GameDataProvider) {
     this.kind = source.kind;
   }
 
   getProject(query: { projectId?: string | null; mapId?: string | null }): Promise<any> {
-    return this.source.getProject(query);
+    let key: string | null = null;
+    if (query.projectId) key = `projectId:${String(query.projectId)}`;
+    else if (query.mapId) key = `mapId:${String(query.mapId)}`;
+
+    if (!key) return this.source.getProject(query);
+    return this.getOrCreate(this.projectByKey, key, () => this.source.getProject(query));
   }
 
   getMap(mapId: string): Promise<any> {
-    return this.source.getMap(mapId);
+    const key = String(mapId);
+    return this.getOrCreate(this.mapById, key, () => this.source.getMap(mapId));
   }
 
   getMedia(mediaId: string): Promise<any> {
     const key = String(mediaId);
-    if (!this.mediaById.has(key)) {
-      const promise = this.source.getMedia(mediaId).catch((error) => {
-        this.mediaById.delete(key);
-        throw error;
-      });
-      this.mediaById.set(key, promise);
-    }
-    return this.mediaById.get(key)!;
+    return this.getOrCreate(this.mediaById, key, () => this.source.getMedia(mediaId));
   }
 
   getDatabase(projectId?: string): Promise<any[]> {
-    return this.source.getDatabase(projectId);
+    const key = String(projectId ?? '');
+    return this.getOrCreate(this.databaseByProjectId, key, () => this.source.getDatabase(projectId));
   }
 
   getPlayerStartConfig?(query: PlayerStartConfigQuery): Promise<any> {
     return this.source.getPlayerStartConfig?.(query) ?? Promise.resolve(null);
+  }
+
+  private getOrCreate<T>(cache: Map<string, Promise<T>>, key: string, load: () => Promise<T>): Promise<T> {
+    const cached = cache.get(key);
+    if (cached) return cached;
+
+    const promise = load().catch((error) => {
+      cache.delete(key);
+      throw error;
+    });
+    cache.set(key, promise);
+    return promise;
   }
 }
 

--- a/packages/studio/tests/data-provider.spec.ts
+++ b/packages/studio/tests/data-provider.spec.ts
@@ -2,15 +2,58 @@ import { describe, expect, test, vi } from "vitest";
 import { createCachedGameDataProvider } from "../src/data-provider/provider-factory";
 import type { GameDataProvider } from "../src/data-provider/types";
 
+const createSource = () =>
+  ({
+    kind: "online" as const,
+    getProject: vi.fn(
+      async (query: { projectId?: string | null; mapId?: string | null }) => ({
+        id: query.projectId ?? query.mapId,
+      })
+    ),
+    getMap: vi.fn(async (id: string) => ({ id })),
+    getDatabase: vi.fn(async (projectId?: string) => [{ projectId }]),
+    getMedia: vi.fn(async (id: string) => ({ id })),
+  } satisfies GameDataProvider);
+
 describe("Studio game data provider", () => {
+  test("deduplicates concurrent project requests", async () => {
+    const source = createSource();
+    const provider = createCachedGameDataProvider(source);
+
+    const first = provider.getProject({ projectId: "project-1" });
+    const second = provider.getProject({ projectId: "project-1" });
+
+    expect(first).toBe(second);
+    await expect(first).resolves.toEqual({ id: "project-1" });
+    expect(source.getProject).toHaveBeenCalledTimes(1);
+  });
+
+  test("deduplicates concurrent map requests", async () => {
+    const source = createSource();
+    const provider = createCachedGameDataProvider(source);
+
+    const first = provider.getMap("map-1");
+    const second = provider.getMap("map-1");
+
+    expect(first).toBe(second);
+    await expect(first).resolves.toEqual({ id: "map-1" });
+    expect(source.getMap).toHaveBeenCalledTimes(1);
+  });
+
+  test("deduplicates concurrent database requests", async () => {
+    const source = createSource();
+    const provider = createCachedGameDataProvider(source);
+
+    const first = provider.getDatabase("project-1");
+    const second = provider.getDatabase("project-1");
+
+    expect(first).toBe(second);
+    await expect(first).resolves.toEqual([{ projectId: "project-1" }]);
+    expect(source.getDatabase).toHaveBeenCalledTimes(1);
+  });
+
   test("deduplicates concurrent media requests", async () => {
-    const source: GameDataProvider = {
-      kind: "online",
-      getProject: vi.fn(),
-      getMap: vi.fn(),
-      getDatabase: vi.fn(),
-      getMedia: vi.fn(async (id: string) => ({ id })),
-    };
+    const source = createSource();
     const provider = createCachedGameDataProvider(source);
 
     const first = provider.getMedia("media-1");
@@ -19,5 +62,80 @@ describe("Studio game data provider", () => {
     expect(first).toBe(second);
     await expect(first).resolves.toEqual({ id: "media-1" });
     expect(source.getMedia).toHaveBeenCalledTimes(1);
+  });
+
+  test("keeps project ID and map ID lookup keys distinct", async () => {
+    const source = createSource();
+    const provider = createCachedGameDataProvider(source);
+
+    await provider.getProject({ projectId: "shared-id" });
+    await provider.getProject({ mapId: "shared-id" });
+    await provider.getProject({ projectId: "shared-id" });
+    await provider.getProject({ mapId: "shared-id" });
+
+    expect(source.getProject).toHaveBeenCalledTimes(2);
+    expect(source.getProject).toHaveBeenNthCalledWith(1, {
+      projectId: "shared-id",
+    });
+    expect(source.getProject).toHaveBeenNthCalledWith(2, {
+      mapId: "shared-id",
+    });
+  });
+
+  test("does not share project, map, or database cache entries between IDs", async () => {
+    const source = createSource();
+    const provider = createCachedGameDataProvider(source);
+
+    await provider.getProject({ projectId: "project-1" });
+    await provider.getProject({ projectId: "project-2" });
+    await provider.getMap("map-1");
+    await provider.getMap("map-2");
+    await provider.getDatabase("project-1");
+    await provider.getDatabase("project-2");
+
+    expect(source.getProject).toHaveBeenCalledTimes(2);
+    expect(source.getMap).toHaveBeenCalledTimes(2);
+    expect(source.getDatabase).toHaveBeenCalledTimes(2);
+  });
+
+  test.each([
+    [
+      "project",
+      (provider: GameDataProvider) =>
+        provider.getProject({ projectId: "project-1" }),
+      "getProject",
+    ],
+    ["map", (provider: GameDataProvider) => provider.getMap("map-1"), "getMap"],
+    [
+      "database",
+      (provider: GameDataProvider) => provider.getDatabase("project-1"),
+      "getDatabase",
+    ],
+    [
+      "media",
+      (provider: GameDataProvider) => provider.getMedia("media-1"),
+      "getMedia",
+    ],
+  ] as const)(
+    "evicts rejected %s requests so they can be retried",
+    async (_name, request, method) => {
+      const source = createSource();
+      source[method].mockRejectedValueOnce(new Error("temporary failure"));
+      const provider = createCachedGameDataProvider(source);
+
+      await expect(request(provider)).rejects.toThrow("temporary failure");
+      await expect(request(provider)).resolves.toBeDefined();
+
+      expect(source[method]).toHaveBeenCalledTimes(2);
+    }
+  );
+
+  test("keeps caches isolated between provider instances", async () => {
+    const source = createSource();
+
+    await createCachedGameDataProvider(source).getDatabase("project-1");
+    await createCachedGameDataProvider(source).getDatabase("project-1");
+
+    expect(source.getDatabase).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
Closes #359

## Summary
- cache in-flight and resolved project, map, database, and media requests per provider instance
- keep project-ID and map-ID lookup keys distinct
- evict rejected requests so later calls can retry
- add a Studio patch changeset and focused regression coverage

## Validation
- `pnpm exec vitest run packages/studio/tests/data-provider.spec.ts` (11 tests)
- `pnpm --filter @rpgjs/studio build`
- packed `@rpgjs/studio` and installed it into `rpgjs/starter` on `v5`
- starter production build and local browser smoke test passed; map rendered, keyboard movement worked, and no browser console errors were reported

## Notes
- the starter `v5` lockfile is currently behind its `package.json`, so its temporary validation install used `pnpm install --no-frozen-lockfile` before installing the local tarball.