### PR TITLE
fix: restore player lifecycle hooks and explicit Studio startup

### DIFF
--- a/.changeset/restore-player-lifecycle.md
+++ b/.changeset/restore-player-lifecycle.md
@@ -1,0 +1,6 @@
+---
+"@rpgjs/common": patch
+"@rpgjs/server": patch
+---
+
+Restore authoritative player onMove hooks and dispatch onDisconnected from lobby, map, and gameplay rooms. Do not report successful room transfers as disconnections or dispatch duplicate disconnection hooks for the same connection.

--- a/.changeset/studio-explicit-direct-start.md
+++ b/.changeset/studio-explicit-direct-start.md
@@ -1,0 +1,5 @@
+---
+"@rpgjs/studio": patch
+---
+
+Start immediately when displayTitleScreen is explicitly false, including when project metadata is unavailable or enables the title screen. Preserve project-driven startup when the option is omitted.

--- a/docs/hooks/server-player-hooks.md
+++ b/docs/hooks/server-player-hooks.md
@@ -30,6 +30,30 @@ export default defineModule({
 })
 ```
 
+## Movement and disconnection
+
+`onMove(player)` runs when authoritative physics changes the player's synchronized
+x/y position, in both standalone RPG and MMORPG modes. It excludes events and
+unchanged positions. Async handlers do not block the physics step; errors are
+logged by the runtime.
+
+`onDisconnected(player)` runs when the last active connection for the session
+closes, whether the player is in the lobby, a map, or a custom gameplay room.
+The room's leave hooks run first. A successful `changeMap()` or `changeRoom()`
+transfer closes the source connection without dispatching `onDisconnected`.
+The destination connection starts a new connection lifecycle.
+
+```ts
+const player: RpgPlayerHooks = {
+    onMove(player) {
+        console.log(player.id, player.x(), player.y())
+    },
+    onDisconnected(player) {
+        console.log(player.id, 'disconnected')
+    }
+}
+```
+
 ## Custom Properties
 
 You can define custom properties that will be synchronized with the client and optionally saved to the database:

--- a/docs/studio/game-integration.md
+++ b/docs/studio/game-integration.md
@@ -456,30 +456,32 @@ provideStudioGame({
 
 ## Start without a title screen
 
-Use `autoStart` when the player should enter the starting map as soon as the
-server connection is established:
+Set `displayTitleScreen: false` to enter the starting map as soon as the
+server accepts the connection, in both standalone RPG and MMORPG modes:
 
 ```ts
 provideStudioGame({
   projectId: "your-project-id",
   startMapId: "requested-map",
   displayTitleScreen: false,
-  autoStart: true,
 });
 ```
 
 The server initializes the built-in default player stats, then transfers the
 player to `startMapId` or to the starting map defined by the Studio project.
-`autoStart` defaults to `false`, so games using the title-screen `start`
-interaction keep their existing behavior. `displayTitleScreen` controls only
-the client display and does not enable immediate startup by itself.
+An explicit `displayTitleScreen: false` enables startup even if the project
+metadata cannot be loaded or its title screen is enabled. Provide `startMapId`
+when startup must work without project metadata. Character selection is still
+honored when project data is available, unless `skipCharacterSelect` is true.
+When `displayTitleScreen` is omitted, the project setting controls the title flow.
+`autoStart: true` remains an explicit immediate-start override.
 
 ## Options
 
 - `projectId`: Studio project identifier. When provided, the default runtime mode is `"online"`.
 - `runtimeMode`: data loading strategy. Use `"online"`, `"offline"`, or `"auto"`.
 - `bundleBasePath`: public path for exported Studio data. Defaults to `/game-data`.
-- `displayTitleScreen`: display the Studio title screen when supported by the project.
+- `displayTitleScreen`: `false` skips the title screen and starts immediately; `true` retains the title flow unless `autoStart: true` overrides it.
 - `autoStart`: initialize the player and enter the starting map immediately on
 connection. Defaults to `false`.
 

--- a/packages/common/src/rooms/Map.ts
+++ b/packages/common/src/rooms/Map.ts
@@ -1677,6 +1677,8 @@ export abstract class RpgCommonMap<T extends RpgCommonPlayer> {
       }
       let changed = false;
 
+      const previousX = typeof currentOwner.x === "function" ? currentOwner.x() : undefined;
+      const previousY = typeof currentOwner.y === "function" ? currentOwner.y() : undefined;
       this.withPhysicsSync(() => {
         if (typeof currentOwner.x === "function" && typeof currentOwner.x.set === "function") {
           currentOwner.x.set(Math.round(topLeftX));
@@ -1688,6 +1690,16 @@ export abstract class RpgCommonMap<T extends RpgCommonPlayer> {
         }
       });
       if (changed) {
+        if (
+          ((typeof currentOwner.x === "function" && previousX !== currentOwner.x()) ||
+            (typeof currentOwner.y === "function" && previousY !== currentOwner.y())) &&
+          typeof currentOwner.execMethod === "function" &&
+          !(typeof currentOwner.isEvent === "function" && currentOwner.isEvent())
+        ) {
+          void Promise.resolve().then(() => currentOwner.execMethod("onMove")).catch((error) => {
+            console.error("[RPGJS] Error during player onMove hooks:", error);
+          });
+        }
         const applyFrames = currentOwner.applyFrames;
         if (typeof applyFrames === "function") {
           queueMicrotask(() => applyFrames.call(currentOwner));

--- a/packages/server/src/Player/Player.ts
+++ b/packages/server/src/Player/Player.ts
@@ -1,3 +1,4 @@
+import { markRoomTransfer } from "../rooms/connection-lifecycle";
 import {
   combineMixins,
   Hooks,
@@ -486,6 +487,7 @@ export class RpgPlayer extends BasicPlayerMixins(RpgCommonPlayer) {
     const transferToken = this.conn
       ? await this.getCurrentRoom()?.$sessionTransfer(this.conn, descriptor.id)
       : undefined;
+    if (this.conn) markRoomTransfer(this.conn, transferToken);
     this.emit("changeMap", {
       ...descriptor,
       mapId: descriptor.id,
@@ -562,6 +564,7 @@ export class RpgPlayer extends BasicPlayerMixins(RpgCommonPlayer) {
       ...descriptor,
       transferToken: typeof transferToken === "string" ? transferToken : undefined,
     };
+    if (this.conn) markRoomTransfer(this.conn, transferToken);
     this.emit("changeRoom", payload);
     return true;
   }

--- a/packages/server/src/RpgServer.ts
+++ b/packages/server/src/RpgServer.ts
@@ -323,7 +323,16 @@ export interface RpgPlayerHooks {
     onDead?: (player: RpgPlayer) => MaybePromise<void>,
 
     /**
-    *  When the player leaves the server
+    * When the last active connection for the player session closes in a lobby,
+    * map, or gameplay room. Runs on the authoritative server in RPG and MMORPG
+    * modes. Successful room transfers do not dispatch this hook.
+    *
+    * @example
+    * ```ts
+    * const player: RpgPlayerHooks = {
+    *   onDisconnected(player) { console.log(player.id, "disconnected"); }
+    * }
+    * ```
     * 
     * @prop { (player: RpgPlayer) => void | Promise<void> } [onDisconnected]
     * @memberof RpgPlayerHooks
@@ -349,7 +358,16 @@ export interface RpgPlayerHooks {
     onOutShape?: (player: RpgPlayer, shape: RpgShape) => MaybePromise<void>
 
     /**
-    * When the x, y positions change
+    * When authoritative physics changes the player's synchronized x/y position.
+    * Runs in RPG and MMORPG modes for players, excluding events and unchanged
+    * positions. Async handlers do not block the physics step.
+    *
+    * @example
+    * ```ts
+    * const player: RpgPlayerHooks = {
+    *   onMove(player) { console.log(player.x(), player.y()); }
+    * }
+    * ```
     * 
     * @prop { (player: RpgPlayer) => void | Promise<void> } [onMove]
     * @since 3.0.0-beta.4

--- a/packages/server/src/rooms/connection-lifecycle.ts
+++ b/packages/server/src/rooms/connection-lifecycle.ts
@@ -1,0 +1,31 @@
+import type { Hooks } from '@rpgjs/common';
+import { lastValueFrom } from 'rxjs';
+import type { RpgPlayer } from '../Player/Player';
+import type { RpgRoomConnection } from './map';
+
+const lifecycleKey = '__rpgjsConnectionLifecycle';
+
+const connectionState = (connection: RpgRoomConnection): Record<string, unknown> =>
+  connection.state && typeof connection.state === 'object'
+    ? connection.state as Record<string, unknown>
+    : {};
+
+/** Mark a successful server-authorized transfer before telling the client to reconnect. */
+export function markRoomTransfer(connection: RpgRoomConnection, token: unknown): void {
+  if (typeof token !== 'string' || token.length === 0) return;
+  connection.setState({ ...connectionState(connection), [lifecycleKey]: 'transferring' });
+}
+
+/** Dispatch once for a closed connection, excluding deliberate room transfers. */
+export async function dispatchPlayerDisconnected(
+  hooks: Hooks,
+  player: RpgPlayer,
+  connection: RpgRoomConnection | null,
+): Promise<void> {
+  if (!connection) return;
+  const state = connectionState(connection);
+  if (state[lifecycleKey] === 'transferring' || state[lifecycleKey] === 'disconnected') return;
+  // Connection state survives room hibernation and is not part of the player snapshot.
+  connection.setState({ ...state, [lifecycleKey]: 'disconnected' });
+  await lastValueFrom(hooks.callHooks('server-player-onDisconnected', player));
+}

--- a/packages/server/src/rooms/gameplay.ts
+++ b/packages/server/src/rooms/gameplay.ts
@@ -1,3 +1,4 @@
+import { dispatchPlayerDisconnected } from "./connection-lifecycle";
 import { UnhandledAction } from "@signe/room";
 import { signal } from "@signe/reactive";
 import { sync, users } from "@signe/sync";
@@ -109,9 +110,10 @@ export class RpgGameplayRoom<TState = Record<string, unknown>> extends BaseRoom 
     this.$applySync?.();
   }
 
-  async onLeave(player: RpgPlayer): Promise<void> {
+  async onLeave(player: RpgPlayer, conn: RpgRoomConnection | null = player.conn): Promise<void> {
     await lastValueFrom(this.hooks.callHooks("server-room-onLeave", player, this));
     await lastValueFrom(this.hooks.callHooks("server-player-onLeaveRoom", player, this));
+    await dispatchPlayerDisconnected(this.hooks, player, conn);
   }
 
   /** Subscribe to an ephemeral client action not handled by a decorated method. */

--- a/packages/server/src/rooms/lobby.ts
+++ b/packages/server/src/rooms/lobby.ts
@@ -11,6 +11,7 @@ import { buildSaveSlotMeta, resolveSaveStorageStrategy } from "../services/save"
 import { lastValueFrom } from "rxjs";
 import type { RpgWritableSignal } from "@rpgjs/common";
 import { RpgRoom } from "./registry";
+import { dispatchPlayerDisconnected } from "./connection-lifecycle";
 
 @RpgRoom({
   kind: "lobby",
@@ -40,9 +41,10 @@ export class LobbyRoom extends BaseRoom {
     (this as any).$applySync?.();
   }
 
-  async onLeave(player: RpgPlayer) {
+  async onLeave(player: RpgPlayer, conn: RpgRoomConnection | null = player.conn) {
     await lastValueFrom(this.hooks.callHooks("server-room-onLeave", player, this));
     await lastValueFrom(this.hooks.callHooks("server-player-onLeaveRoom", player, this));
+    await dispatchPlayerDisconnected(this.hooks, player, conn);
   }
 
   @Action('gui.interaction')

--- a/packages/server/src/rooms/map.ts
+++ b/packages/server/src/rooms/map.ts
@@ -1,3 +1,4 @@
+import { dispatchPlayerDisconnected } from "./connection-lifecycle";
 import { Action, Request, UnhandledAction } from "@signe/room";
 import {
   Hooks,
@@ -1739,6 +1740,7 @@ export class RpgMap extends RpgCommonMap<RpgPlayer> {
     if (!this.hasActiveConnections()) {
       this.setAutoTick(false);
     }
+    await dispatchPlayerDisconnected(this.hooks, player, conn);
   }
 
   /**

--- a/packages/server/tests/gameplay-room.spec.ts
+++ b/packages/server/tests/gameplay-room.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { h, Container } from "canvasengine";
 import { testing, type TestingFixture } from "@rpgjs/testing";
 import { defineModule } from "@rpgjs/common";
@@ -41,9 +41,12 @@ class BattleRoom extends RpgGameplayRoom<BattleState> {
 @RpgRoom({ kind: "duel", path: "battle-{slug}" })
 class AmbiguousBattleRoom extends RpgGameplayRoom {}
 
+const onDisconnected = vi.fn();
+
 const serverModule = defineModule<RpgServer>({
   maps: [{ id: "start", file: "" }],
   player: {
+    onDisconnected,
     onConnected(player) {
       player.setVariable("transfer-proof", "preserved");
     },
@@ -57,6 +60,8 @@ const clientModule = defineModule<RpgClient>({});
 
 describe("custom gameplay rooms", () => {
   let fixture: TestingFixture | undefined;
+
+  beforeEach(() => onDisconnected.mockClear());
 
   afterEach(async () => {
     await fixture?.clear();
@@ -121,11 +126,15 @@ describe("custom gameplay rooms", () => {
     expect(player.getVariable("transfer-proof")).toBe("preserved");
     expect(player.snapshot?.()).toMatchObject({ variables: { "transfer-proof": "preserved" } });
 
+    const sourceMapConnection = player.conn!;
     const battleChange = client.waitForRoomChange("battle");
     expect(await player.changeRoom({ kind: "battle", params: { id: "encounter-42" } })).toBe(true);
     player = await battleChange;
     await fixture.wait(0);
 
+    sourceMapConnection.close();
+    await fixture.wait(50);
+    expect(onDisconnected).not.toHaveBeenCalled();
     const room = player.getCurrentRoom<BattleRoom>();
     expect(player.snapshot?.()).toMatchObject({ variables: { "transfer-proof": "preserved" } });
     expect(player.id).toBe(playerId);
@@ -154,6 +163,7 @@ describe("custom gameplay rooms", () => {
     await fixture.wait(0);
     expect(client.client.sceneRoom.state()).toEqual({ turn: 2, lastPlayerId: playerId });
 
+    const sourceBattleConnection = player.conn!;
     expect(await player.changeMap("start", { x: 220, y: 240 })).toBe(true);
     await fixture.wait(200);
     player = client.player;
@@ -163,5 +173,14 @@ describe("custom gameplay rooms", () => {
     expect(player.y()).toBe(240);
     expect(player.getVariable("transfer-proof")).toBe("preserved");
     expect(client.client.activeSceneKind()).toBe("map");
+    sourceBattleConnection.close();
+    await fixture.wait(50);
+    expect(onDisconnected).not.toHaveBeenCalled();
+
+    const battleAgain = client.waitForRoomChange("battle");
+    await player.changeRoom({ kind: "battle", params: { id: "another" } });
+    player = await battleAgain;
+    player.conn!.close();
+    await vi.waitFor(() => expect(onDisconnected).toHaveBeenCalledOnce());
   });
 });

--- a/packages/server/tests/lobby.spec.ts
+++ b/packages/server/tests/lobby.spec.ts
@@ -66,6 +66,30 @@ describe("LobbyRoom", () => {
     expect(hooks.callHooks).toHaveBeenCalledWith("server-player-onStart", player);
   });
 
+  test("client connection close runs onDisconnected", async () => {
+    const onDisconnected = vi.fn();
+    const serverModule = defineModule<RpgServer>({
+      player: { onDisconnected },
+    });
+    const serverClass = createServer({
+      providers: [provideServerModules([serverModule])],
+    });
+    const room = new ServerIo("lobby-1", { env: { TEST: "true" } });
+    const server = new serverClass(room);
+    await server.onStart();
+    await server.subRoom.onStart();
+    const client = new ClientIo(server, "player-client-id");
+    const request = new Request("http://localhost", {
+      method: "GET",
+      headers: { "Content-Type": "application/json" },
+    });
+    await server.onConnect(client.conn as any, { request } as any);
+    room.clients.set(client.id, client);
+
+    client.conn.close();
+    await vi.waitFor(() => expect(onDisconnected).toHaveBeenCalledOnce());
+  });
+
   test("client title screen interaction reaches lobby and runs onStart", async () => {
     let onStartCalls = 0;
     const serverModule = defineModule<RpgServer>({

--- a/packages/server/tests/move.spec.ts
+++ b/packages/server/tests/move.spec.ts
@@ -1,8 +1,10 @@
-import { beforeEach, test, expect, afterEach, describe } from "vitest";
+import { beforeEach, test, expect, afterEach, describe, vi } from "vitest";
 import { testing, TestingFixture } from "@rpgjs/testing";
 import { defineModule, createModule, Direction } from "@rpgjs/common";
 import { RpgPlayer, RpgServer, Move } from "../src";
 import { RpgClient } from "../../client/src";
+
+let onMoveCalls = 0;
 
 // Define server module with test map
 const serverModule = defineModule<RpgServer>({
@@ -15,6 +17,9 @@ const serverModule = defineModule<RpgServer>({
   player: {
     async onConnected(player) {
       await player.changeMap("test-map", { x: 100, y: 100 });
+    },
+    onMove() {
+      onMoveCalls += 1;
     },
   },
 });
@@ -29,6 +34,7 @@ let client: any;
 let fixture: TestingFixture;
 
 beforeEach(async () => {
+  onMoveCalls = 0;
   const myModule = createModule("TestModule", [
     {
       server: serverModule,
@@ -48,6 +54,23 @@ afterEach(async () => {
 
 
 describe("Move Routes - Basic Movements", () => {
+  test("does not dispatch onMove for unchanged positions or events", async () => {
+    const body = player.getCurrentMap()!.getBody(player.id)!;
+    onMoveCalls = 0;
+    body.notifyPositionChange();
+    await Promise.resolve();
+    expect(onMoveCalls).toBe(0);
+    vi.spyOn(player, 'isEvent').mockReturnValue(true);
+    await fixture.waitUntil(player.moveRoutes([Direction.Right]));
+    expect(onMoveCalls).toBe(0);
+  });
+
+  test("calls the player onMove hook when its position changes", async () => {
+    await fixture.waitUntil(player.moveRoutes([Direction.Right]));
+
+    expect(onMoveCalls).toBeGreaterThan(0);
+  });
+
   test("should create player physics body with rectangular RPG hitbox and speed", async () => {
     const map = player.getCurrentMap() as any;
     const entity = map.getBody(player.id);

--- a/packages/server/tests/player-connection-lifecycle.spec.ts
+++ b/packages/server/tests/player-connection-lifecycle.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test, vi } from 'vitest';
+import { createModule, defineModule } from '@rpgjs/common';
+import { testing } from '@rpgjs/testing';
+import type { RpgPlayer, RpgServer } from '../src';
+
+test('room transfers do not disconnect the player; closing the destination does, once', async () => {
+  const onDisconnected = vi.fn();
+  const onLeaveMap = vi.fn();
+  const onLeaveRoom = vi.fn();
+  let lobbyPlayer: RpgPlayer;
+  const fixture = await testing(createModule('DisconnectReview', [{
+    server: defineModule<RpgServer>({
+      maps: [{ id: 'test-map', file: '' }, { id: 'second-map', file: '' }],
+      player: {
+        async onConnected(player) { lobbyPlayer = player; await player.changeMap('test-map'); },
+        onDisconnected,
+        onLeaveMap,
+        onLeaveRoom,
+      },
+    }),
+    client: defineModule({}),
+  }]));
+  try {
+    const client = await fixture.createClient();
+    const player = await client.waitForMapChange('test-map');
+    lobbyPlayer!.conn!.close();
+    await vi.waitFor(() => expect(onLeaveRoom).toHaveBeenCalled());
+    expect(onDisconnected).not.toHaveBeenCalled();
+
+    await player.changeMap('second-map');
+    const destination = await client.waitForMapChange('second-map');
+    player.conn!.close();
+    await vi.waitFor(() => expect(onLeaveMap).toHaveBeenCalledOnce());
+    expect(onDisconnected).not.toHaveBeenCalled();
+    onLeaveMap.mockClear();
+    destination.conn!.close();
+    await vi.waitFor(() => expect(onLeaveMap).toHaveBeenCalled());
+    await vi.waitFor(() => expect(onDisconnected).toHaveBeenCalledOnce());
+    destination.conn!.close();
+    await vi.waitFor(() => expect(onLeaveMap).toHaveBeenCalledTimes(2));
+    expect(onDisconnected).toHaveBeenCalledOnce();
+  } finally {
+    await fixture.clear();
+  }
+});

--- a/packages/server/tests/prediction-reconciliation.spec.ts
+++ b/packages/server/tests/prediction-reconciliation.spec.ts
@@ -29,6 +29,8 @@ function createStreamingDefinition(): MapStreamDefinition {
   };
 }
 
+let onMoveCalls = 0;
+
 const serverModule = defineModule<RpgServer>({
   maps: [
     {
@@ -40,6 +42,9 @@ const serverModule = defineModule<RpgServer>({
     async onConnected(player) {
       await player.changeMap("test-map", { x: 100, y: 100 });
     },
+    onMove() {
+      onMoveCalls += 1;
+    },
   },
 });
 
@@ -49,6 +54,7 @@ let player: RpgPlayer;
 let serverMap: any;
 
 beforeEach(async () => {
+  onMoveCalls = 0;
   const module = createModule("PredictionServerModule", [
     {
       server: serverModule,
@@ -65,6 +71,18 @@ afterEach(async () => {
 });
 
 describe("Prediction + Reconciliation Server Protocol", () => {
+  test("should call onMove after authoritative movement input changes position", async () => {
+    await serverMap.onInput(player, {
+      input: Direction.Right,
+      frame: 1,
+      tick: 0,
+      timestamp: Date.now(),
+    });
+    await serverMap.nextTickAsync();
+
+    expect(onMoveCalls).toBeGreaterThan(0);
+  });
+
   test("should reply pong with server tick", () => {
     const emitSpy = vi.spyOn(player, "emit");
     const payload = {

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -59,14 +59,15 @@ export interface StudioGameModuleConfig {
   baseUrl?: string;
   assetsUrl?: string;
   apiUrl?: string;
+  /** Set false to skip the title screen and start immediately in RPG and MMORPG modes. */
   displayTitleScreen?: boolean;
   /**
    * Start the player as soon as the server connection is established.
    *
    * The server initializes the default player stats and transfers the player
    * to `startMapId`, or to the starting map resolved from the Studio project.
-   * Defaults to `false`. Set `displayTitleScreen: false` separately when the
-   * client should also skip the Studio title screen.
+   * Defaults to `false`. `displayTitleScreen: false` also enables immediate
+   * startup, even when project metadata cannot be loaded.
    */
   autoStart?: boolean;
   startMapId?: string;

--- a/packages/studio/src/server.ts
+++ b/packages/studio/src/server.ts
@@ -1062,6 +1062,7 @@ export default (_config?: unknown) => {
   };
   const shouldAutoStart = async (playerConfig: StudioServerConfig) => {
     if (playerConfig.autoStart === true) return true;
+    if (playerConfig.displayTitleScreen === false) return true;
     if (playerConfig.displayTitleScreen === true) return false;
     const project = await resolveStudioProject(undefined, playerConfig);
     return project?.menus?.titleScreen?.enabled === false;

--- a/packages/studio/tests/studio-server-runtime.spec.ts
+++ b/packages/studio/tests/studio-server-runtime.spec.ts
@@ -32,6 +32,27 @@ afterEach(() => {
 });
 
 describe("Studio server runtime", () => {
+  test.each(["unavailable", "enabled"] as const)("explicit hidden title screen starts when project title screen is %s", async (projectState) => {
+    const player = { initializeDefaultStats: vi.fn(), changeMap: vi.fn() };
+    const hooks = (studioServer({
+      displayTitleScreen: false,
+      startMapId: "requested-map",
+      dataProvider: {
+        kind: "online",
+        getProject: async () => {
+          if (projectState === "unavailable") throw new Error("project unavailable");
+          return { menus: { titleScreen: { enabled: true } } };
+        },
+        getMap: vi.fn(), getMedia: vi.fn(), getDatabase: async () => [],
+      },
+    }) as any).player;
+    await hooks.onAccepted(player, { connection: {}, query: {}, headers: {} });
+    expect(player.initializeDefaultStats).toHaveBeenCalledOnce();
+    expect(player.changeMap).toHaveBeenCalledWith("requested-map");
+    await hooks.onStart(player);
+    expect(player.changeMap).toHaveBeenCalledOnce();
+  });
+
   test("publishes the generated Studio class in every map database", async () => {
     const databaseProvider = (studioServer() as any).database as (map: RpgMap) => Promise<Record<string, any>>;
     const database = await databaseProvider({
@@ -124,9 +145,10 @@ describe("Studio server runtime", () => {
     expect(changeMap).toHaveBeenCalledWith("requested-map");
   });
 
-  test("resolves the project start map for immediate startup", async () => {
+  test.each([{ autoStart: true }, { displayTitleScreen: false }])("resolves the project start map for immediate startup %j", async (startupOptions) => {
+    const projectId = `auto-start-project-${Object.keys(startupOptions)[0]}`;
     const getProject = vi.fn(async () => ({
-      _id: "auto-start-project",
+      _id: projectId,
       startMapId: "project-start-map",
     }));
     configureGameDataProvider({
@@ -139,8 +161,8 @@ describe("Studio server runtime", () => {
     const initializeDefaultStats = vi.fn();
     const changeMap = vi.fn(async () => true);
     const hooks = (studioServer({
-      autoStart: true,
-      projectId: "auto-start-project",
+      ...startupOptions,
+      projectId: projectId,
     }) as any).player;
 
     await hooks.onAccepted({
@@ -149,7 +171,7 @@ describe("Studio server runtime", () => {
     }, acceptedContext());
 
     expect(getProject).toHaveBeenCalledWith({
-      projectId: "auto-start-project",
+      projectId: projectId,
     });
     expect(initializeDefaultStats).toHaveBeenCalledOnce();
     expect(changeMap).toHaveBeenCalledWith("project-start-map");


### PR DESCRIPTION
Closing a map connection previously ran only room/map leave hooks, and the proposed lobby-only fix still missed players already in game. Dispatch `onDisconnected` once from lobby, map, and custom gameplay rooms, while preserving room leave hooks and excluding successful server-authorized transfers. Restore `onMove` after authoritative position changes, excluding events and unchanged positions.

An explicit `displayTitleScreen: false` now starts Studio players even when project metadata is unavailable or enables its title screen. Omitted options retain the project-driven startup flow, and `autoStart: true` remains an override.

Includes regression tests, player-hook and Studio documentation, and patch changesets. Package versions are unchanged; this PR does not release packages.

Validation:
- 103 focused lifecycle/startup tests passed.
- 30 public type-contract tests passed; public API boundary check passed.
- All 12 packages built successfully.
- Packed common/server/studio into the v5 starter: production build, rendered map and keyboard movement passed, without JavaScript errors. Native Vite import/chunk warnings and the favicon 404 also occur with published packages.
- Both GitHub Actions runs passed the complete test suite, Cloudflare MMORPG/Studio tests and playground/sample builds.
- The local full suite had 1,412 passing tests and one timing-sensitive metrics failure (`metrics.tick` was still zero); that four-test file passed when rerun, and both complete CI runs passed.
- A temporary starter hook counter confirmed that the packed packages dispatch `onMove` during keyboard movement.

Supersedes #362.
Fixes #344.
Fixes #358.
