### PR TITLE
fix: preserve runtime actor changes through Studio restoration

### DIFF
--- a/.changeset/preserve-runtime-actors.md
+++ b/.changeset/preserve-runtime-actors.md
@@ -1,0 +1,6 @@
+---
+"@rpgjs/server": patch
+"@rpgjs/studio": patch
+---
+
+Preserve switched actors, chosen classes and progression when restoring Studio players. Persist parameter curve bounds and Studio initialization state, rebuild derived parameters instead of loading over their runtime signal, restore actor presentation without granting starting inventory again, and normalize Studio media and hitbox records for character selection. Apply combat animation bindings in changeActor.

--- a/docs/api/player/class-commands.md
+++ b/docs/api/player/class-commands.md
@@ -9,6 +9,7 @@ Assign and inspect player classes and class-driven behaviors.
 
 ## Members
 
+- [animations](#animations)
 - [Change Actor](#change-actor)
 - [changeActor](#changeactor)
 - [createClassInstance](#createclassinstance)
@@ -17,12 +18,28 @@ Assign and inspect player classes and class-driven behaviors.
 - [setClass](#setclass)
 - [WithClassManager](#withclassmanager)
 
+## animations
+
+Animation names mapped to graphics, consumed by optional combat modules.
+
+- Source: `packages/server/src/Player/ClassManager.ts`
+- Kind: `property`
+- Defined in: `ActorData`
+
+### Signature
+
+```ts
+animations: Record<string, string>
+```
+
 ## Change Actor
 
 Replace the player's active actor identity while preserving acquired
 progression. The new actor's parameter curves are evaluated at the
 current level and HP/SP keep their previous fill ratios. Starting
-equipment is intentionally not granted.
+equipment is intentionally not granted. Runs on the authoritative server
+in standalone RPG and MMORPG modes. Animation bindings are available to
+optional combat modules through `combatAnimations`.
 
 - Source: `packages/server/src/Player/ClassManager.ts`
 - Kind: `method`
@@ -41,6 +58,13 @@ player.changeActor(actor)
 ### Returns
 
 The resolved actor object.
+
+### Examples
+
+```ts
+const actor = await player.showCharacterSelect([Hero, Mage], { allowCancel: true });
+if (actor) player.changeActor(actor);
+```
 
 ## changeActor
 

--- a/docs/api/player/common-commands.md
+++ b/docs/api/player/common-commands.md
@@ -9,6 +9,7 @@ Core server-side player commands defined on the main Player class.
 
 ## Members
 
+- [Apply Player Snapshot](#apply-player-snapshot)
 - [applyDefaultParameters](#applydefaultparameters)
 - [attachShape](#attachshape)
 - [cameraFollow](#camerafollow)
@@ -32,9 +33,11 @@ Core server-side player commands defined on the main Player class.
 - [load](#load)
 - [otherPlayersCollision](#otherplayerscollision)
 - [pendingMapPosition](#pendingmapposition)
+- [Player Snapshot](#player-snapshot)
 - [playSound](#playsound)
 - [position](#position)
 - [position](#position)
+- [prepareSnapshotForObjectLoad](#preparesnapshotforobjectload)
 - [Remove listeners of the client event](#remove-listeners-of-the-client-event)
 - [room](#room)
 - [Run Sync Changes](#run-sync-changes)
@@ -54,6 +57,36 @@ Core server-side player commands defined on the main Player class.
 - [tiles](#tiles)
 - [worldPositionX](#worldpositionx)
 - [worldPositionY](#worldpositiony)
+
+## Apply Player Snapshot
+
+Restore authoritative player state without new-game initialization in RPG
+and MMORPG modes, then run the server onLoad hooks.
+
+- Source: `packages/server/src/Player/Player.ts`
+- Kind: `method`
+- Member of: `RpgPlayer`
+- Defined in: `RpgPlayer`
+
+### Signature
+
+```ts
+player.applySnapshot(snapshot)
+```
+
+### Parameters
+
+- `snapshot`: `string | RpgPlayerSnapshot`
+
+### Returns
+
+The resolved snapshot after database references have been restored.
+
+### Examples
+
+```ts
+await player.applySnapshot(saved);
+```
 
 ## applyDefaultParameters
 
@@ -758,6 +791,32 @@ Internal: named map position to resolve after the target map data is ready
 pendingMapPosition
 ```
 
+## Player Snapshot
+
+Capture serializable authoritative player state in RPG and MMORPG modes.
+Derived parameters are recalculated from saved curves, bounds and modifiers.
+
+- Source: `packages/server/src/Player/Player.ts`
+- Kind: `method`
+- Member of: `RpgPlayer`
+- Defined in: `RpgPlayer`
+
+### Signature
+
+```ts
+player.snapshot()
+```
+
+### Returns
+
+Player state suitable for serialization and later restoration.
+
+### Examples
+
+```ts
+const saved = JSON.stringify(player.snapshot());
+```
+
 ## playSound
 
 Play a sound on the client side for this player only
@@ -838,6 +897,28 @@ when the player is currently attached to a map.
 ```ts
 position
 ```
+
+## prepareSnapshotForObjectLoad
+
+Preserve runtime signals while preparing serialized player data for loading.
+
+- Source: `packages/server/src/Player/Player.ts`
+- Kind: `method`
+- Defined in: `RpgPlayer`
+
+### Signature
+
+```ts
+prepareSnapshotForObjectLoad(snapshot: RpgPlayerSnapshot): RpgPlayerSnapshot
+```
+
+### Parameters
+
+- `snapshot`: `RpgPlayerSnapshot`
+
+### Returns
+
+A copy excluding fields that are restored separately or recomputed.
 
 ## Remove listeners of the client event
 

--- a/docs/api/player/parameter-commands.md
+++ b/docs/api/player/parameter-commands.md
@@ -650,8 +650,10 @@ player.finalLevel = 50
 player.finalLevel = 50
 ```
 
+The server retains this curve bound in saves and room transfers in both RPG and MMORPG modes.
+
 - Source: `packages/server/src/Player/ParameterManager.ts`
-- Kind: `property`
+- Kind: `getter`
 - Member of: `ParameterManager`
 
 ### Signature
@@ -695,8 +697,10 @@ player.initialLevel = 5
 player.initialLevel = 5
 ```
 
+The server retains this curve bound in saves and room transfers in both RPG and MMORPG modes.
+
 - Source: `packages/server/src/Player/ParameterManager.ts`
-- Kind: `property`
+- Kind: `getter`
 - Member of: `ParameterManager`
 
 ### Signature

--- a/docs/gui/character-select.md
+++ b/docs/gui/character-select.md
@@ -43,3 +43,28 @@ properties remain server-side. Register `graphic`, `illustration`, and
 Projects can replace the CanvasEngine component by registering another GUI with
 `PrebuiltGui.CharacterSelect`; preserve the interactions documented in
 [Prebuilt GUI Contracts](/gui/prebuilt-contracts).
+
+## Switching actors during play
+
+Use `changeActor()` when reopening the selector during gameplay:
+
+```ts
+const actor = await player.showCharacterSelect([Hero, Mage], {
+  selectedActorId: "hero",
+  allowCancel: true,
+})
+if (actor) player.changeActor(actor)
+```
+
+The authoritative server applies the actor's name, graphic, hitbox, default class,
+parameter curves and combat animation bindings. Level, experience, inventory,
+equipment, learned skills, states and modifiers are retained. HP/SP keep their
+fill ratios, and starting equipment is not granted again. Cancellation applies
+no actor changes. `setActor()` remains the initialization API.
+
+In Studio, the `call_character_select` block offers all Actors or an ordered
+`actorIds` subset and persists the chosen Actor ID. It normalizes Studio media
+references before calling the server API. `change_class` can then select another
+resolved Class. Saves and room transfers retain that class, the selected Actor,
+and progression; restoring a player does not grant starting inventory again.
+These rules apply in both standalone RPG and MMORPG modes.

--- a/packages/server/src/Player/ClassManager.ts
+++ b/packages/server/src/Player/ClassManager.ts
@@ -20,6 +20,8 @@ export interface ActorData {
   class?: ClassInput;
   graphic?: string | number | (string | number)[];
   hitbox?: { width: number; height: number };
+  /** Animation names mapped to graphics, consumed by optional combat modules. */
+  animations?: Record<string, string>;
   [key: string]: unknown;
 }
 
@@ -184,7 +186,15 @@ export function WithClassManager<TBase extends PlayerCtor>(Base: TBase) {
      * Replace the player's active actor identity while preserving acquired
      * progression. The new actor's parameter curves are evaluated at the
      * current level and HP/SP keep their previous fill ratios. Starting
-     * equipment is intentionally not granted.
+     * equipment is intentionally not granted. Runs on the authoritative server
+     * in standalone RPG and MMORPG modes. Animation bindings are available to
+     * optional combat modules through `combatAnimations`.
+     *
+     * @example
+     * ```ts
+     * const actor = await player.showCharacterSelect([Hero, Mage], { allowCancel: true });
+     * if (actor) player.changeActor(actor);
+     * ```
      *
      * @title Change Actor
      * @method player.changeActor(actor)
@@ -210,6 +220,7 @@ export function WithClassManager<TBase extends PlayerCtor>(Base: TBase) {
       if (actor.class) this.setClass(actor.class);
       if (actor.graphic !== undefined) player.setGraphic?.(actor.graphic);
       if (actor.hitbox) player.setHitbox?.(actor.hitbox.width, actor.hitbox.height);
+      player.combatAnimations = { ...(actor.animations ?? {}) };
 
       player.execMethod("onSet", [this], actor);
       if (player._exp?.set) player._exp.set(experience);

--- a/packages/server/src/Player/ParameterManager.ts
+++ b/packages/server/src/Player/ParameterManager.ts
@@ -485,6 +485,9 @@ export function WithParameterManager<TBase extends PlayerCtor>(Base: TBase) {
         this as never
     ) as unknown as RpgWritableSignal<ParameterCurveMap>
 
+    private _initialLevelSignal = type(signal(1) as never, '_initialLevelSignal', { persist: true }, this as never) as unknown as RpgWritableSignal<number>
+    private _finalLevelSignal = type(signal(99) as never, '_finalLevelSignal', { persist: true }, this as never) as unknown as RpgWritableSignal<number>
+
     private _paramProxy: { [key: string]: number } | null = null
 
     /**
@@ -583,24 +586,28 @@ export function WithParameterManager<TBase extends PlayerCtor>(Base: TBase) {
      * player.initialLevel = 5
      * ``` 
      * 
+     * The server retains this curve bound in saves and room transfers in both RPG and MMORPG modes.
      * @title Set initial level
      * @prop {number} player.initialLevel
      * @default 1
      * @memberof ParameterManager
      * */
-    public initialLevel:number = 1
+    get initialLevel(): number { return this._initialLevelSignal() }
+    set initialLevel(value: number) { this._initialLevelSignal.set(value) }
 
     /** 
      * ```ts
      * player.finalLevel = 50
      * ``` 
      * 
+     * The server retains this curve bound in saves and room transfers in both RPG and MMORPG modes.
      * @title Set final level
      * @prop {number} player.finalLevel
      * @default 99
      * @memberof ParameterManager
      * */
-    public finalLevel:number = 99
+    get finalLevel(): number { return this._finalLevelSignal() }
+    set finalLevel(value: number) { this._finalLevelSignal.set(value) }
 
     /** 
      * With Object-based syntax, you can use following options:

--- a/packages/server/src/Player/ParameterManager.ts
+++ b/packages/server/src/Player/ParameterManager.ts
@@ -511,9 +511,11 @@ export function WithParameterManager<TBase extends PlayerCtor>(Base: TBase) {
         const parameters = this._parametersSignal()
         const allModifiers = this._getAggregatedModifiers()
         const level = this._level()
+        const initialLevel = this.initialLevel
+        const finalLevel = this.finalLevel
         
         for (const [name, paramConfig] of Object.entries(parameters)) {
-            let curveVal = Math.floor((paramConfig.end - paramConfig.start) * ((level - 1) / (this.finalLevel - this.initialLevel))) + paramConfig.start
+            let curveVal = Math.floor((paramConfig.end - paramConfig.start) * ((level - 1) / (finalLevel - initialLevel))) + paramConfig.start
             
             const modifier = allModifiers[name]
             if (modifier) {

--- a/packages/server/src/Player/Player.ts
+++ b/packages/server/src/Player/Player.ts
@@ -939,19 +939,26 @@ export class RpgPlayer extends BasicPlayerMixins(RpgCommonPlayer) {
     });
   }
 
+  /**
+   * Preserve runtime signals while preparing serialized player data for loading.
+   * @internal
+   * @param snapshot - Player state received by the server restoration path.
+   * @returns A copy excluding fields that are restored separately or recomputed.
+   */
   prepareSnapshotForObjectLoad(snapshot: RpgPlayerSnapshot): RpgPlayerSnapshot {
     if (!snapshot || typeof snapshot !== "object") {
       return snapshot;
     }
 
-    const hitbox = this.normalizeSnapshotHitbox(snapshot.hitbox);
-    if (!hitbox) {
-      return snapshot;
-    }
-
-    this.hitbox.set(hitbox);
+    // Derived parameters must be recomputed from the restored curves, level and
+    // modifiers. Loading their serialized values can overwrite the computed signal.
     const rest = { ...snapshot };
-    delete rest.hitbox;
+    delete rest._param;
+    const hitbox = this.normalizeSnapshotHitbox(snapshot.hitbox);
+    if (hitbox) {
+      this.hitbox.set(hitbox);
+      delete rest.hitbox;
+    }
     return rest;
   }
 
@@ -973,6 +980,18 @@ export class RpgPlayer extends BasicPlayerMixins(RpgCommonPlayer) {
       : null;
   }
 
+  /**
+   * Capture serializable authoritative player state in RPG and MMORPG modes.
+   * Derived parameters are recalculated from saved curves, bounds and modifiers.
+   * @title Player Snapshot
+   * @method player.snapshot()
+   * @returns Player state suitable for serialization and later restoration.
+   * @memberof RpgPlayer
+   * @example
+   * ```ts
+   * const saved = JSON.stringify(player.snapshot());
+   * ```
+   */
   snapshot(): RpgPlayerSnapshot {
     const snapshot = createStatesSnapshotDeep(this) as RpgPlayerSnapshot;
     delete (snapshot as any).pendingMapPosition;
@@ -996,6 +1015,19 @@ export class RpgPlayer extends BasicPlayerMixins(RpgCommonPlayer) {
     return snapshot;
   }
 
+  /**
+   * Restore authoritative player state without new-game initialization in RPG
+   * and MMORPG modes, then run the server onLoad hooks.
+   * @title Apply Player Snapshot
+   * @method player.applySnapshot(snapshot)
+   * @param snapshot - A serialized snapshot or a parsed player snapshot.
+   * @returns The resolved snapshot after database references have been restored.
+   * @memberof RpgPlayer
+   * @example
+   * ```ts
+   * await player.applySnapshot(saved);
+   * ```
+   */
   async applySnapshot(snapshot: string | RpgPlayerSnapshot): Promise<RpgPlayerSnapshot> {
     const data = (typeof snapshot === "string" ? JSON.parse(snapshot) : snapshot) as RpgPlayerSnapshot;
     if (data && typeof data === "object" && typeof (data as any).locale === "string") {
@@ -1015,7 +1047,7 @@ export class RpgPlayer extends BasicPlayerMixins(RpgCommonPlayer) {
     const withStates = (this as any).resolveStatesSnapshot?.(withSkills) ?? withSkills;
     const withClass = (this as any).resolveClassSnapshot?.(withStates) ?? withStates;
     const resolvedSnapshot = ((this as any).resolveEquipmentsSnapshot?.(withClass) ?? withClass) as RpgPlayerSnapshot;
-    load(this, resolvedSnapshot);
+    load(this, this.prepareSnapshotForObjectLoad(resolvedSnapshot));
     if (resolvedSnapshot.expCurve) {
       (this as any).expCurve = resolvedSnapshot.expCurve;
     }

--- a/packages/server/tests/class.spec.ts
+++ b/packages/server/tests/class.spec.ts
@@ -316,6 +316,39 @@ describe("Class Manager - setActor", () => {
 });
 
 describe("Class Manager - changeActor", () => {
+  test("preserves actor parameter curves and class through a serialized snapshot", async () => {
+    player.level = 12;
+    player.changeActor({
+      id: "saved-actor", initialLevel: 3, finalLevel: 60,
+      parameters: { [MAXHP]: { start: 200, end: 800 } },
+      class: { id: "actor-class", name: "Actor Class" },
+      animations: { attack: "sword" },
+    });
+    player.hp = Math.round(player.param[MAXHP] / 2);
+    const expectedMaxHp = player.param[MAXHP];
+    const snapshot = JSON.parse(JSON.stringify(player.snapshot()));
+    // Older snapshots also serialized this derived object. It must not replace
+    // the destination player's computed parameter signal.
+    snapshot._param = { maxHp: expectedMaxHp };
+    const restored = new RpgPlayer();
+    await restored.applySnapshot(snapshot);
+    expect(restored.level).toBe(player.level);
+    expect(restored.initialLevel).toBe(player.initialLevel);
+    expect(restored.finalLevel).toBe(player.finalLevel);
+    expect(restored.param[MAXHP]).toBe(expectedMaxHp);
+    expect(restored.hp).toBe(player.hp);
+    expect(restored._class()).toMatchObject({ id: "actor-class" });
+    restored.level += 1;
+    expect(restored.param[MAXHP]).toBeGreaterThan(expectedMaxHp);
+  });
+
+  test("applies actor combat animations and clears the previous actor's animations", () => {
+    player.changeActor({ id: "mage", animations: { attack: "magic" } });
+    expect((player as any).combatAnimations).toEqual({ attack: "magic" });
+    player.changeActor({ id: "other" });
+    expect((player as any).combatAnimations).toEqual({});
+  });
+
   test("should apply a new actor while preserving progression", () => {
     player.parameters = {
       [MAXHP]: { start: 200, end: 200 },

--- a/packages/server/tests/server-api-types.spec.ts
+++ b/packages/server/tests/server-api-types.spec.ts
@@ -101,7 +101,7 @@ describe("server public API types", () => {
         .toEqualTypeOf<Promise<ActorData | null>>();
       expectTypeOf(player.setActor({ id: "hero", name: "Hero" }))
         .toEqualTypeOf<ActorData>();
-      expectTypeOf(player.changeActor({ id: "mage", name: "Mage" }))
+      expectTypeOf(player.changeActor({ id: "mage", name: "Mage", animations: { attack: "magic" }, class: { id: "caster", name: "Caster" } }))
         .toEqualTypeOf<ActorData>();
     };
 

--- a/packages/studio/runtime/blocks/executors/call-character-select.ts
+++ b/packages/studio/runtime/blocks/executors/call-character-select.ts
@@ -1,3 +1,5 @@
+import { getGraphicKey, getGraphicScale } from "../../../src/graphic-key";
+import { normalizeRuntimeHitbox } from "../../../src/runtime-hitbox";
 import { excludeTriggers } from '../context-helpers';
 import type { BlockExecutor } from '../types';
 
@@ -9,6 +11,7 @@ type StudioDatabaseRecord = Record<string, unknown> & {
   classId?: unknown;
   class?: unknown;
   animations?: unknown;
+  params?: unknown;
 };
 
 const recordType = (record: unknown): unknown => {
@@ -101,7 +104,12 @@ export const call_character_select: BlockExecutor<'call_character_select'> = asy
   const presentationActors = offeredActors.map((actor) => {
     const classRecord = typeof actor.classId === 'string' ? database[actor.classId] : actor.class;
     const resolvedClass = classRecord && recordType(classRecord) === 'class' ? classRecord : undefined;
-    return { ...actor, class: resolvedClass };
+    return {
+      ...actor,
+      graphic: getGraphicKey(actor.graphic) ?? undefined,
+      hitbox: normalizeRuntimeHitbox(actor.hitbox),
+      class: resolvedClass,
+    };
   });
   const selected = await player.showCharacterSelect(presentationActors, {
     selectedActorId: currentActorId(player),
@@ -113,6 +121,7 @@ export const call_character_select: BlockExecutor<'call_character_select'> = asy
   const actor = presentationActors.find((candidate) => candidate.id === selectedId);
   if (!actor) return;
   player.changeActor(actor);
+  player._graphicScale?.set(getGraphicScale(actor.params, actor) ?? null);
   player.studioCombatAnimations = actor.animations ?? {};
   player.combatAnimations = actor.animations ?? {};
   persistActorId(player, actor.id);

--- a/packages/studio/src/runtime-hitbox.ts
+++ b/packages/studio/src/runtime-hitbox.ts
@@ -1,0 +1,15 @@
+export const normalizeRuntimeHitbox = (value: unknown): { width: number; height: number } | undefined => {
+  if (!value || typeof value !== "object") return undefined;
+  const record = value as Record<string, unknown>;
+  const rawWidth = record.width ?? record.w;
+  const rawHeight = record.height ?? record.h;
+  const width = typeof rawWidth === "number" ? rawWidth : Number(rawWidth);
+  const height = typeof rawHeight === "number" ? rawHeight : Number(rawHeight);
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return undefined;
+  }
+  return {
+    width: Math.max(1, Math.round(width)),
+    height: Math.max(1, Math.round(height)),
+  };
+};

--- a/packages/studio/src/server.ts
+++ b/packages/studio/src/server.ts
@@ -1136,12 +1136,23 @@ export default (_config?: unknown) => {
         await applyStartGameOnce(player, map, heroConfig);
         applyPlayerPresentation(player, heroConfig);
       },
-      onLoad: async (player: RpgPlayer) => {
+      onLoad: async (player: RpgPlayer, snapshot) => {
         // Loading a saved game is never new-game initialization, including old
         // saves that predate the persisted initialization marker.
         markStudioInitialized(player);
         const map = player.getCurrentMap();
-        if (map) applyPlayerPresentation(player, await resolvePlayerConfig(player, map));
+        if (map) {
+          const config = await resolvePlayerConfig(player, map);
+          // Older saves did not persist these bounds. Recover them from the
+          // selected actor where possible without overwriting modern snapshots.
+          if (snapshot && snapshot._initialLevelSignal === undefined && config.initialLevel !== undefined) {
+            player.initialLevel = Math.min(config.initialLevel, player.level);
+          }
+          if (snapshot && snapshot._finalLevelSignal === undefined && config.finalLevel !== undefined) {
+            player.finalLevel = Math.max(config.finalLevel, player.level);
+          }
+          applyPlayerPresentation(player, config);
+        }
       },
       onInput: (player: RpgPlayer, input: RpgActionInput<unknown>) => {
         if (input.action == "escape") {

--- a/packages/studio/src/server.ts
+++ b/packages/studio/src/server.ts
@@ -1,3 +1,4 @@
+import { normalizeRuntimeHitbox } from "./runtime-hitbox";
 import { Move, RpgEvent, RpgMap, RpgPlayer, RpgServer, provideServerMapStreaming, type RpgPlayerConnectionContext } from "@rpgjs/server";
 import { defineModule, normalizeLightingState, WorldMapsManager, type RpgActionInput, type WorldMapConfig } from "@rpgjs/common";
 import { BlockExecutionService } from "./block-executor";
@@ -96,22 +97,6 @@ const readGameConfig = (): any => {
   return globalScope.window?.gameConfig ?? globalScope.gameConfig ?? {};
 };
 
-const normalizeRuntimeHitbox = (value: unknown): { width: number; height: number } | undefined => {
-  if (!value || typeof value !== "object") return undefined;
-  const record = value as Record<string, unknown>;
-  const rawWidth = record.width ?? record.w;
-  const rawHeight = record.height ?? record.h;
-  const width = typeof rawWidth === "number" ? rawWidth : Number(rawWidth);
-  const height = typeof rawHeight === "number" ? rawHeight : Number(rawHeight);
-  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
-    return undefined;
-  }
-  return {
-    width: Math.max(1, Math.round(width)),
-    height: Math.max(1, Math.round(height)),
-  };
-};
-
 export const resolveRuntimeEventHitbox = (object: any, params: any): { width: number; height: number } | undefined => {
   const triggerHitbox = Array.isArray(object?.triggers)
     ? [...object.triggers].reverse().find((trigger: any) => trigger?.enabled !== false && normalizeRuntimeHitbox(trigger?.hitbox))?.hitbox
@@ -199,13 +184,23 @@ const startGame = async (player: RpgPlayer, map?: RpgMap, heroConfig?: ProjectBa
   applyPlayerHitbox(player, heroConfig);
 };
 
-const applyStartGameOnce = async (player: RpgPlayer, map?: RpgMap, heroConfig?: ProjectBasic) => {
+const markStudioInitialized = (player: RpgPlayer): void => {
   const runtimePlayer = player as RpgPlayer & {
+    studioStartGameApplied?: { set(value: boolean): void };
     __studioStartGameApplied?: boolean;
   };
-  if (runtimePlayer.__studioStartGameApplied) return;
-  await startGame(player, map, heroConfig);
+  runtimePlayer.studioStartGameApplied?.set(true);
   runtimePlayer.__studioStartGameApplied = true;
+};
+
+const applyStartGameOnce = async (player: RpgPlayer, map?: RpgMap, heroConfig?: ProjectBasic) => {
+  const runtimePlayer = player as RpgPlayer & {
+    studioStartGameApplied?: () => boolean;
+    __studioStartGameApplied?: boolean;
+  };
+  if (runtimePlayer.studioStartGameApplied?.() || runtimePlayer.__studioStartGameApplied) return;
+  await startGame(player, map, heroConfig);
+  markStudioInitialized(player);
 };
 
 const collectStartingItemIds = (config: ProjectBasic): string[] => {
@@ -226,6 +221,15 @@ const applyPlayerHitbox = (player: RpgPlayer, config: ProjectBasic): void => {
   const hitbox = normalizeRuntimeHitbox((config as any).hitbox);
   if (!hitbox || typeof (player as any).setHitbox !== "function") return;
   (player as any).setHitbox(hitbox.width, hitbox.height);
+};
+
+const applyPlayerPresentation = (player: RpgPlayer, config: ProjectBasic & { graphic?: unknown; params?: unknown }): void => {
+  const graphicKey = getGraphicKey(config.graphic);
+  (player as any)._graphicScale?.set(graphicKey ? getGraphicScale(config.params, config) ?? null : null);
+  player.setGraphic(graphicKey ?? "default_character");
+  (player as any).studioCombatAnimations = config.animations ?? {};
+  (player as any).combatAnimations = config.animations ?? {};
+  applyPlayerHitbox(player, config);
 };
 
 const addStudioDefaultClass = (
@@ -1085,6 +1089,11 @@ export default (_config?: unknown) => {
   return defineModule<RpgServer>({
     player: {
       props: {
+        studioStartGameApplied: {
+          $default: false,
+          $syncWithClient: false,
+          $permanent: true,
+        },
         studioSelectedActorId: {
           $default: null,
           $syncWithClient: false,
@@ -1124,17 +1133,15 @@ export default (_config?: unknown) => {
 
         await refreshOnlineStudioDatabase(map);
         const heroConfig = await resolvePlayerConfig(player, map);
-        const heroGraphic = (heroConfig as any)?.graphic;
-        const heroGraphicKey = getGraphicKey(heroGraphic);
-        if (heroGraphicKey) {
-          (player as any)._graphicScale?.set(getGraphicScale((heroConfig as any)?.params, heroConfig) ?? null);
-          player.setGraphic(heroGraphicKey);
-        } else {
-          (player as any)._graphicScale?.set(null);
-          player.setGraphic("default_character");
-        }
-
         await applyStartGameOnce(player, map, heroConfig);
+        applyPlayerPresentation(player, heroConfig);
+      },
+      onLoad: async (player: RpgPlayer) => {
+        // Loading a saved game is never new-game initialization, including old
+        // saves that predate the persisted initialization marker.
+        markStudioInitialized(player);
+        const map = player.getCurrentMap();
+        if (map) applyPlayerPresentation(player, await resolvePlayerConfig(player, map));
       },
       onInput: (player: RpgPlayer, input: RpgActionInput<unknown>) => {
         if (input.action == "escape") {

--- a/packages/studio/tests/character-blocks-runtime.spec.ts
+++ b/packages/studio/tests/character-blocks-runtime.spec.ts
@@ -11,6 +11,34 @@ const executionContext = (player: Record<string, any>, database: Record<string, 
 } as any);
 
 describe('character workflow blocks', () => {
+  test.each([null, { id: 'not-offered' }])('does not mutate player state for cancellation or an unknown selection: %j', async (selection) => {
+    const player = {
+      studioSelectedActorId: 'original',
+      showCharacterSelect: vi.fn(async () => selection),
+      changeActor: vi.fn(),
+      combatAnimations: { attack: 'original' },
+    };
+    await call_character_select(executionContext(player, {
+      candidate: { _type: 'actor', name: 'Candidate' },
+    }), { allActors: true, actorIds: [], allowCancel: true });
+    expect(player.changeActor).not.toHaveBeenCalled();
+    expect(player.studioSelectedActorId).toBe('original');
+    expect(player.combatAnimations).toEqual({ attack: 'original' });
+  });
+
+  test('normalizes Studio media references and hitboxes before switching actors', async () => {
+    const player = {
+      showCharacterSelect: vi.fn(async (actors) => actors[0]),
+      changeActor: vi.fn(),
+    };
+    await call_character_select(executionContext(player, {
+      mage: { _type: 'actor', graphic: { _id: 'mage-sheet' }, hitbox: { w: 20, h: 28 } },
+    }), { allActors: true, actorIds: [], allowCancel: false });
+    expect(player.changeActor).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'mage', graphic: 'mage-sheet', hitbox: { width: 20, height: 28 },
+    }));
+  });
+
   test('registers the character selector and class blocks', () => {
     const characterSelect = defaultBlocks.find((block) => block.type === 'call_character_select');
     const changeClass = defaultBlocks.find((block) => block.type === 'change_class');

--- a/packages/studio/tests/studio-server-runtime.spec.ts
+++ b/packages/studio/tests/studio-server-runtime.spec.ts
@@ -32,6 +32,67 @@ afterEach(() => {
 });
 
 describe("Studio server runtime", () => {
+  test.each(["snapshot", "legacy-save"])("restores a switched actor without resetting progression or a manually selected class: %s", async (mode) => {
+    const actor = {
+      _id: "runtime-actor", _type: "actor", name: "Mage",
+      graphic: "mage-graphic", initialLevel: 2, finalLevel: 60,
+      classId: "default-class",
+      parameters: { [MAXHP]: { start: 200, end: 800 }, [MAXSP]: { start: 80, end: 160 } },
+      animations: { attack: "magic-attack" },
+      startingInventory: [{ itemId: "potion", amount: 2 }],
+      startingEquipment: { weapon: "sword" },
+    };
+    const hooks = (studioServer() as any).player;
+    configureGameDataProvider({
+      kind: "online", getProject: vi.fn(), getMap: vi.fn(), getMedia: vi.fn(),
+      getDatabase: vi.fn(async () => [actor, { _id: "default-class", _type: "class", name: "Default" }, { _id: "potion", _type: "item", name: "Potion" }, { _id: "sword", _type: "weapon", name: "Sword" }]),
+    });
+    const database: Record<string, any> = {};
+    const map = {
+      globalConfig: { _id: "restore-actor-project", hero: { initialLevel: 1, startingInventory: [{ itemId: "potion", amount: 2 }], startingEquipment: { weapon: "sword" } } },
+      database: () => database,
+      addInDatabase(id: string, value: unknown) { database[id] = value; },
+      scale: 1,
+    } as unknown as RpgMap;
+    const makePlayer = () => {
+      const player = new RpgPlayer();
+      player.setSync(hooks.props);
+      (player as any).execMethod = vi.fn(async () => undefined);
+      player.initializeDefaultStats();
+      player.setMap(map);
+      return player;
+    };
+    const player = makePlayer();
+    await hooks.onJoinMap(player, map);
+    player.level = 12;
+    player.exp = 500;
+    player.changeActor(actor);
+    (player as any).studioSelectedActorId.set("runtime-actor");
+    player.setClass({ id: "chosen-class", name: "Chosen" });
+    player.hp = Math.round(player.param[MAXHP] / 2);
+    player.sp = Math.round(player.param[MAXSP] / 4);
+    expect(player.getItem("potion")?.quantity()).toBe(2);
+    const snapshot = JSON.parse(JSON.stringify(player.snapshot()));
+    if (mode === "legacy-save") delete snapshot.studioStartGameApplied;
+    const restored = makePlayer();
+    await restored.applySnapshot(snapshot);
+    if (mode === "legacy-save") await hooks.onLoad(restored);
+    const addItem = vi.spyOn(restored, "addItem");
+    await hooks.onJoinMap(restored, map);
+    expect(restored.level).toBe(player.level);
+    expect(restored.exp).toBe(player.exp);
+    expect(restored.hp).toBe(player.hp);
+    expect(restored.sp).toBe(player.sp);
+    expect(restored._class()).toMatchObject({ id: "chosen-class" });
+    expect((restored as any).studioSelectedActorId()).toBe("runtime-actor");
+    expect(restored.graphics()).toContain("mage-graphic");
+    expect((restored as any).studioCombatAnimations).toEqual({ attack: "magic-attack" });
+    expect(addItem).not.toHaveBeenCalled();
+    expect(restored.getItem("potion")?.quantity()).toBe(2);
+    expect(restored.getItem("sword")?.quantity()).toBe(1);
+    expect(restored.equipments()).toHaveLength(1);
+  });
+
   test.each(["unavailable", "enabled"] as const)("explicit hidden title screen starts when project title screen is %s", async (projectState) => {
     const player = { initializeDefaultStats: vi.fn(), changeMap: vi.fn() };
     const hooks = (studioServer({

--- a/packages/studio/tests/studio-server-runtime.spec.ts
+++ b/packages/studio/tests/studio-server-runtime.spec.ts
@@ -73,14 +73,19 @@ describe("Studio server runtime", () => {
     player.sp = Math.round(player.param[MAXSP] / 4);
     expect(player.getItem("potion")?.quantity()).toBe(2);
     const snapshot = JSON.parse(JSON.stringify(player.snapshot()));
-    if (mode === "legacy-save") delete snapshot.studioStartGameApplied;
+    if (mode === "legacy-save") {
+      delete snapshot.studioStartGameApplied;
+      delete snapshot._initialLevelSignal;
+      delete snapshot._finalLevelSignal;
+    }
     const restored = makePlayer();
     await restored.applySnapshot(snapshot);
-    if (mode === "legacy-save") await hooks.onLoad(restored);
+    if (mode === "legacy-save") await hooks.onLoad(restored, snapshot);
     const addItem = vi.spyOn(restored, "addItem");
     await hooks.onJoinMap(restored, map);
     expect(restored.level).toBe(player.level);
     expect(restored.exp).toBe(player.exp);
+    expect(restored.param[MAXHP]).toBe(player.param[MAXHP]);
     expect(restored.hp).toBe(player.hp);
     expect(restored.sp).toBe(player.sp);
     expect(restored._class()).toMatchObject({ id: "chosen-class" });


### PR DESCRIPTION
Runtime actor switching existed, but restoring a Studio player could reapply new-game stats, default class and starting inventory. Actor parameter-curve bounds also reverted to defaults, and loading a derived `_param` snapshot could overwrite its computed signal.

Persist curve bounds and Studio initialization state, preserve runtime parameter signals on restoration, and restore presentation separately from new-game initialization. `changeActor` now applies combat animation bindings. The Studio selector normalizes media/hitbox records and retains server-owned candidate validation.

Includes serialized snapshot and legacy-save tests with a chosen class, inventory and equipment; reactive parameter restoration tests; animation, cancellation, unknown-selection and Studio media tests; public type coverage; regenerated API docs and a patch changeset. Package versions remain unchanged; no release is requested.

Validation:
- Full suite: 194 files passed; 1,420 tests passed, 16 existing skips.
- Final legacy-restoration and class regression run: 58 tests passed, 2 existing skips.
- 30 public type-contract tests passed; no type errors. Public boundary check passed for 27 entry points.
- All packages built; affected server/studio rebuilt and packed after the final fix.
- Packed artifacts installed in the v5 starter; production build passed. Browser selector changed Hero to Mage and restored the snapshot with identical level (12), HP (207/413), graphic and class. Screenshot reviewed, no runtime errors. Favicon 404 and existing Vite/native-import/chunk warnings also reproduce with published packages.
- Both GitHub Actions runs passed on final commit `60d22d9416a33a6b00839bc9da414ea7ed18a496`, including Cloudflare runtime tests and playground/sample builds. Publishing jobs were skipped.

Fixes #346.
